### PR TITLE
feat: adds retryWrites arg

### DIFF
--- a/src/aind_data_access_api/document_store.py
+++ b/src/aind_data_access_api/document_store.py
@@ -27,6 +27,7 @@ class Client:
         self,
         credentials: DocumentStoreCredentials,
         collection_name: Optional[str] = None,
+        retry_writes: Optional[bool] = True
     ):
         """
         Construct a client to interface with a document store.
@@ -34,6 +35,10 @@ class Client:
         ----------
         credentials: CoreCredentials
         collection_name : Optional[str]
+        retry_writes : Optional[bool]
+          Whether supported write operations executed within the MongoClient
+          will be retried once after a network error. Default is True. Set to
+          False if writing to AWS DocumentDB.
         """
         self.credentials = credentials
         self.collection_name = collection_name
@@ -42,6 +47,7 @@ class Client:
             port=credentials.port,
             username=credentials.username,
             password=credentials.password.get_secret_value(),
+            retryWrites=retry_writes
         )
 
     @property

--- a/src/aind_data_access_api/document_store.py
+++ b/src/aind_data_access_api/document_store.py
@@ -27,7 +27,7 @@ class Client:
         self,
         credentials: DocumentStoreCredentials,
         collection_name: Optional[str] = None,
-        retry_writes: Optional[bool] = True
+        retry_writes: Optional[bool] = True,
     ):
         """
         Construct a client to interface with a document store.
@@ -47,7 +47,7 @@ class Client:
             port=credentials.port,
             username=credentials.username,
             password=credentials.password.get_secret_value(),
-            retryWrites=retry_writes
+            retryWrites=retry_writes,
         )
 
     @property

--- a/tests/test_document_store.py
+++ b/tests/test_document_store.py
@@ -167,6 +167,35 @@ class TestClient(unittest.TestCase):
 
         mock_log_info.assert_called_once_with("Documents Upserted")
 
+    def test_retry_writes(self):
+        """Tests that the retryWrites option can be set."""
+        ds_client1 = Client(
+            credentials=DocumentStoreCredentials(
+                username="user",
+                password="password",
+                host="localhost",
+                database="db",
+            ),
+            collection_name="coll",
+        )
+        ds_client2 = Client(
+            credentials=DocumentStoreCredentials(
+                username="user",
+                password="password",
+                host="localhost",
+                database="db",
+            ),
+            collection_name="coll",
+            retry_writes=False
+        )
+
+        self.assertTrue(
+            ds_client1._client._MongoClient__options._options["retryWrites"]
+        )
+        self.assertFalse(
+            ds_client2._client._MongoClient__options._options["retryWrites"]
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_document_store.py
+++ b/tests/test_document_store.py
@@ -186,7 +186,7 @@ class TestClient(unittest.TestCase):
                 database="db",
             ),
             collection_name="coll",
-            retry_writes=False
+            retry_writes=False,
         )
 
         self.assertTrue(

--- a/tests/test_secrets_access.py
+++ b/tests/test_secrets_access.py
@@ -1,8 +1,10 @@
 """Test secrets_access module."""
 import unittest
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
+
 from botocore.exceptions import ClientError
-from aind_data_access_api.secrets import get_secret, get_parameter
+
+from aind_data_access_api.secrets import get_parameter, get_secret
 
 
 class TestSecretAccess(unittest.TestCase):


### PR DESCRIPTION
Closes #18

- Adds option to set retryWrites in the MongoClient to False
- Runs linters