### PR TITLE
fix: updates docdb record upsert

### DIFF
--- a/src/aind_data_access_api/document_db.py
+++ b/src/aind_data_access_api/document_db.py
@@ -154,7 +154,9 @@ class MetadataDbClient(Client):
                 {
                     "UpdateOne": {
                         "filter": {"_id": rec.id},
-                        "update": {"$set": rec.json(by_alias=True)},
+                        "update": {
+                            "$set": json.loads(rec.json(by_alias=True))
+                        },
                         "upsert": "True",
                     }
                 }

--- a/tests/test_document_db.py
+++ b/tests/test_document_db.py
@@ -236,7 +236,7 @@ class TestMetadataDbClient(unittest.TestCase):
                     "UpdateOne": {
                         "filter": {"_id": "abc-123"},
                         "update": {
-                            "$set": (
+                            "$set": json.loads(
                                 '{"_id": "abc-123",'
                                 ' "_name": "modal_00000_2000-10-10_10-10-10",'
                                 ' "_created": "2000-10-10T10:10:10",'
@@ -252,7 +252,7 @@ class TestMetadataDbClient(unittest.TestCase):
                     "UpdateOne": {
                         "filter": {"_id": "abc-125"},
                         "update": {
-                            "$set": (
+                            "$set": json.loads(
                                 '{"_id": "abc-125",'
                                 ' "_name": "modal_00001_2000-10-10_10-10-10",'
                                 ' "_created": "2000-10-10T10:10:10",'


### PR DESCRIPTION
- hot fix to converts json string to json obj when upserting docs through the api