### PR TITLE
feat: updates rds api to handle redshift

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ docdb = [
 ]
 rds = [
     "psycopg2-binary==2.9.5",
-    "pandas==1.5.3 ",
-    "SQLAlchemy==2.0.7"
+    "pandas==2.1.0",
+    "SQLAlchemy==1.4.49"
 ]
 full = [
     "aind-data-access-api[secrets]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ docdb = [
 ]
 rds = [
     "psycopg2-binary==2.9.5",
-    "pandas==2.1.0",
+    "pandas>=2.0.0",
     "SQLAlchemy==1.4.49"
 ]
 full = [


### PR DESCRIPTION
Closes #23

- Can mostly use old rds api
- Needed to downgrade to SQLAlchemy==1.4.49 to get things to work
- Needed to set index=False since Redshift doesn't support indexing
- Used method='multi' for pandas method instead of custom method. This will be slower for writing large tables, but hopefully quick enough.