### PR TITLE
hot-fix: docdb json serializer

### DIFF
--- a/src/aind_data_access_api/document_db.py
+++ b/src/aind_data_access_api/document_db.py
@@ -140,7 +140,7 @@ class MetadataDbClient(Client):
 
         response = self._upsert_one_record(
             record_filter={"_id": data_asset_record.id},
-            update={"$set": data_asset_record.json(by_alias=True)},
+            update={"$set": json.loads(data_asset_record.json(by_alias=True))},
         )
         return response
 

--- a/tests/test_document_db.py
+++ b/tests/test_document_db.py
@@ -202,7 +202,7 @@ class TestMetadataDbClient(unittest.TestCase):
         self.assertEqual({"message": "success"}, response)
         mock_upsert.assert_called_once_with(
             record_filter={"_id": "abc-123"},
-            update={"$set": data_asset_record.json(by_alias=True)},
+            update={"$set": json.loads(data_asset_record.json(by_alias=True))},
         )
 
     @patch("aind_data_access_api.document_db.Client._bulk_write")


### PR DESCRIPTION
- hot fix to serialize json properly to be able to write to the docdb