### PR TITLE
feat: updates pydantic version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,9 @@ dynamic = ["version"]
 
 dependencies = [
     "requests",
-    "pydantic==1.10.6"
+    "aind-codeocean-api>=0.4.0",
+    "pydantic>=2.0",
+    "pydantic-settings>=2.0"
 ]
 
 [project.optional-dependencies]
@@ -33,8 +35,7 @@ dev = [
     "aind-data-access-api[full]"
 ]
 secrets = [
-    "boto3==1.26.94",
-    "botocore==1.29.94"
+    "boto3",
 ]
 docdb = [
     "pymongo==4.3.3"

--- a/src/aind_data_access_api/credentials.py
+++ b/src/aind_data_access_api/credentials.py
@@ -1,44 +1,15 @@
 """Module to manage credentials to connect to databases."""
 
-import json
-import logging
-from enum import Enum, auto
-from typing import Any, Dict, Optional
+from typing import Optional, Tuple, Type
 
-import boto3
-from botocore.exceptions import ClientError
-from pydantic import BaseSettings, Field, SecretStr
-
-
-class AutoName(Enum):
-    """Autogenerate name using auto feature. Retrieved from
-    https://stackoverflow.com/a/32313954"""
-
-    def _generate_next_value_(self, start, count, last_values):
-        """Hack to get auto to reflect var name instead of int"""
-        return self
-
-
-# TODO: There's a bug with pycharm warning about auto. The latest version
-#  of Pycharm should fix it.
-# noinspection PyArgumentList
-class EnvVarKeys(str, AutoName):
-    """Enum of the names of the environment variables to check."""
-
-    DOC_STORE_USER = auto()
-    DOC_STORE_PASSWORD = auto()
-    DOC_STORE_HOST = auto()
-    DOC_STORE_PORT = auto()
-    DOC_STORE_DATABASE = auto()
-    RDS_USER = auto()
-    RDS_PASSWORD = auto()
-    RDS_HOST = auto()
-    RDS_PORT = auto()
-    RDS_DATABASE = auto()
-
-    def __str__(self):
-        """As a default, have the string representation just be the value."""
-        return str(self.value)
+from aind_codeocean_api.credentials import AWSConfigSettingsSource
+from pydantic import Field, SecretStr
+from pydantic_settings import (
+    BaseSettings,
+    EnvSettingsSource,
+    InitSettingsSource,
+    PydanticBaseSettingsSource,
+)
 
 
 class CoreCredentials(BaseSettings):
@@ -54,80 +25,48 @@ class CoreCredentials(BaseSettings):
     port: int = Field(...)
     database: str = Field(...)
 
-    class Config:
-        """This class will add custom sourcing from aws."""
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: Type[BaseSettings],
+        init_settings: InitSettingsSource,
+        env_settings: EnvSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> Tuple[PydanticBaseSettingsSource, ...]:
+        """
+        Method to pull configs from a variety sources, such as a file or aws.
+        Arguments are required and set by pydantic.
+        Parameters
+        ----------
+        settings_cls : Type[BaseSettings]
+          Top level class. Model fields can be pulled from this.
+        init_settings : InitSettingsSource
+          The settings in the init arguments.
+        env_settings : EnvSettingsSource
+          The settings pulled from environment variables.
+        dotenv_settings : PydanticBaseSettingsSource
+          Settings from .env files. Currently, not supported.
+        file_secret_settings : PydanticBaseSettingsSource
+          Settings from secret files such as used in Docker. Currently, not
+          supported.
 
-        @staticmethod
-        def settings_from_aws(secrets_name: Optional[str]):  # noqa: C901
-            """
-            Curried function that returns a function to retrieve creds from aws
-            Parameters
-            ----------
-            secrets_name : Name of the credentials we wish to retrieve
+        Returns
+        -------
+        Tuple[PydanticBaseSettingsSource, ...]
 
-            Returns
-            -------
-            A function that retrieves the credentials.
+        """
+        aws_secrets_path = init_settings.init_kwargs.get("aws_secrets_name")
 
-            """
-
-            def set_settings(_: BaseSettings) -> Dict[str, Any]:
-                """
-                A simple settings source that loads from aws secrets manager
-                """
-                sm_client = boto3.client("secretsmanager")
-                try:
-                    secret_from_aws = sm_client.get_secret_value(
-                        SecretId=secrets_name
-                    )
-                    secret_as_string = secret_from_aws["SecretString"]
-                    secrets_json = json.loads(secret_as_string)
-                    secrets = {}
-                    # Map to our secrets model
-                    if secrets_json.get("username"):
-                        secrets["username"] = secrets_json.get("username")
-                    if secrets_json.get("password"):
-                        secrets["password"] = secrets_json.get("password")
-                    if secrets_json.get("host"):
-                        secrets["host"] = secrets_json.get("host")
-                    if secrets_json.get("port"):
-                        secrets["port"] = secrets_json.get("port")
-                    if secrets_json.get("dbname"):
-                        secrets["database"] = secrets_json.get("dbname")
-                    if secrets_json.get("database"):
-                        secrets["database"] = secrets_json.get("database")
-                except ClientError as e:
-                    logging.warning(
-                        f"Unable to retrieve parameters from aws: {e.response}"
-                    )
-                    secrets = {}
-                finally:
-                    sm_client.close()
-                return secrets
-
-            return set_settings
-
-        @classmethod
-        def customise_sources(
-            cls,
-            init_settings,
-            env_settings,
-            file_secret_settings,
-        ):
-            """Class method to return custom sources."""
-            aws_secrets_name = init_settings.init_kwargs.get(
-                "aws_secrets_name"
+        # If user defines aws secrets, create creds from there
+        if aws_secrets_path is not None:
+            return (
+                init_settings,
+                AWSConfigSettingsSource(settings_cls, aws_secrets_path),
             )
-            if aws_secrets_name:
-                return (
-                    init_settings,
-                    env_settings,
-                    file_secret_settings,
-                    cls.settings_from_aws(secrets_name=aws_secrets_name),
-                )
-            else:
-                return (
-                    init_settings,
-                    env_settings,
-                    file_secret_settings,
-                )
+        # Otherwise, create creds from init and env
+        else:
+            return (
+                init_settings,
+                env_settings,
+            )

--- a/src/aind_data_access_api/document_db.py
+++ b/src/aind_data_access_api/document_db.py
@@ -283,7 +283,11 @@ class MetadataDbClient(Client):
 
         response = self._upsert_one_record(
             record_filter={"_id": data_asset_record.id},
-            update={"$set": json.loads(data_asset_record.json(by_alias=True))},
+            update={
+                "$set": json.loads(
+                    data_asset_record.model_dump_json(by_alias=True)
+                )
+            },
         )
         return response
 
@@ -329,7 +333,9 @@ class MetadataDbClient(Client):
             end_index = len(data_asset_records)
             second_index = 1
             responses = []
-            record_json = data_asset_records[first_index].json(by_alias=True)
+            record_json = data_asset_records[first_index].model_dump_json(
+                by_alias=True
+            )
             total_size = getsizeof(record_json)
             operations = [
                 self._record_to_operation(
@@ -342,9 +348,9 @@ class MetadataDbClient(Client):
                     response = self._bulk_write(operations)
                     responses.append(response)
                 else:
-                    record_json = data_asset_records[second_index].json(
-                        by_alias=True
-                    )
+                    record_json = data_asset_records[
+                        second_index
+                    ].model_dump_json(by_alias=True)
                     record_size = getsizeof(record_json)
                     if total_size + record_size > max_payload_size:
                         response = self._bulk_write(operations)

--- a/src/aind_data_access_api/rds_tables.py
+++ b/src/aind_data_access_api/rds_tables.py
@@ -4,21 +4,29 @@ from typing import Optional, Union
 
 import pandas as pd
 import sqlalchemy.engine
-from pydantic import Field, SecretStr
+from pydantic import AliasChoices, Field, SecretStr
+from pydantic_settings import SettingsConfigDict
 from sqlalchemy import create_engine, engine, text
 from sqlalchemy.engine.cursor import CursorResult
 
-from aind_data_access_api.credentials import CoreCredentials, EnvVarKeys
+from aind_data_access_api.credentials import CoreCredentials
 
 
 class RDSCredentials(CoreCredentials):
     """RDS db credentials"""
 
-    username: str = Field(..., env=EnvVarKeys.RDS_USER.value)
-    password: SecretStr = Field(..., env=EnvVarKeys.RDS_PASSWORD.value)
-    host: str = Field(..., env=EnvVarKeys.RDS_HOST.value)
-    port: int = Field(default=5432, env=EnvVarKeys.RDS_PORT.value)
-    database: str = Field(..., env=EnvVarKeys.RDS_DATABASE.value)
+    model_config = SettingsConfigDict(env_prefix="RDS_")
+
+    # Setting validation aliases for legacy purposes. Allows users
+    # to use RDS_USER in addition to RDS_USERNAME as env vars
+    username: str = Field(
+        ...,
+        validation_alias=AliasChoices("username", "RDS_USER", "RDS_USERNAME"),
+    )
+    password: SecretStr = Field(...)
+    host: str = Field(...)
+    port: int = Field(default=5432)
+    database: str = Field(...)
 
 
 class Client:

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -5,44 +5,9 @@ import os
 import unittest
 from unittest.mock import MagicMock, patch
 
-from aind_data_access_api.credentials import CoreCredentials, EnvVarKeys
+from aind_data_access_api.credentials import CoreCredentials
 from aind_data_access_api.document_store import DocumentStoreCredentials
 from aind_data_access_api.rds_tables import RDSCredentials
-
-
-class TestEnvVarKeys(unittest.TestCase):
-    """Tests that the env var keys enums are sound"""
-
-    def test_env_var_keys(self):
-        """Test that the string representation is same as value."""
-
-        self.assertEqual(
-            EnvVarKeys.DOC_STORE_PASSWORD.value,
-            str(EnvVarKeys.DOC_STORE_PASSWORD),
-        )
-        self.assertEqual(
-            EnvVarKeys.DOC_STORE_USER.value, str(EnvVarKeys.DOC_STORE_USER)
-        )
-        self.assertEqual(
-            EnvVarKeys.DOC_STORE_HOST.value, str(EnvVarKeys.DOC_STORE_HOST)
-        )
-        self.assertEqual(
-            EnvVarKeys.DOC_STORE_PORT.value, str(EnvVarKeys.DOC_STORE_PORT)
-        )
-        self.assertEqual(
-            EnvVarKeys.DOC_STORE_DATABASE.value,
-            str(EnvVarKeys.DOC_STORE_DATABASE),
-        )
-        self.assertEqual(
-            EnvVarKeys.RDS_PASSWORD.value,
-            str(EnvVarKeys.RDS_PASSWORD),
-        )
-        self.assertEqual(EnvVarKeys.RDS_USER.value, str(EnvVarKeys.RDS_USER))
-        self.assertEqual(EnvVarKeys.RDS_HOST.value, str(EnvVarKeys.RDS_HOST))
-        self.assertEqual(EnvVarKeys.RDS_PORT.value, str(EnvVarKeys.RDS_PORT))
-        self.assertEqual(
-            EnvVarKeys.RDS_DATABASE.value, str(EnvVarKeys.RDS_DATABASE)
-        )
 
 
 class TestCoreCredentials(unittest.TestCase):
@@ -177,20 +142,26 @@ class TestDocumentStoreCredentials(unittest.TestCase):
         )
         creds4 = DocumentStoreCredentials(host="my_host", database="my_db")
 
-        self.assertEqual("fake_user", creds1.username)
-        self.assertEqual("fake_password", creds1.password.get_secret_value())
+        self.assertEqual("user_from_aws", creds1.username)
+        self.assertEqual(
+            "password_from_aws", creds1.password.get_secret_value()
+        )
         self.assertEqual("host_from_aws", creds1.host)
-        self.assertEqual(12346, creds1.port)
+        self.assertEqual(12345, creds1.port)
         self.assertEqual("db_from_aws", creds1.database)
 
         self.assertEqual("my_user", creds2.username)
-        self.assertEqual("fake_password", creds2.password.get_secret_value())
+        self.assertEqual(
+            "password_from_aws", creds2.password.get_secret_value()
+        )
         self.assertEqual("host_from_aws", creds2.host)
-        self.assertEqual(12346, creds2.port)
+        self.assertEqual(12345, creds2.port)
         self.assertEqual("db_from_aws", creds2.database)
 
         self.assertEqual("my_user", creds3.username)
-        self.assertEqual("fake_password", creds3.password.get_secret_value())
+        self.assertEqual(
+            "password_from_aws", creds3.password.get_secret_value()
+        )
         self.assertEqual("host_from_aws", creds3.host)
         self.assertEqual(5678, creds3.port)
         self.assertEqual("db_from_aws", creds3.database)

--- a/tests/test_document_db.py
+++ b/tests/test_document_db.py
@@ -295,7 +295,11 @@ class TestMetadataDbClient(unittest.TestCase):
         self.assertEqual({"message": "success"}, response)
         mock_upsert.assert_called_once_with(
             record_filter={"_id": "abc-123"},
-            update={"$set": json.loads(data_asset_record.json(by_alias=True))},
+            update={
+                "$set": json.loads(
+                    data_asset_record.model_dump_json(by_alias=True)
+                )
+            },
         )
 
     @patch("aind_data_access_api.document_db.Client._bulk_write")

--- a/tests/test_document_store.py
+++ b/tests/test_document_store.py
@@ -1,5 +1,5 @@
 """Test document_store module."""
-
+import json
 import unittest
 from datetime import datetime
 from unittest.mock import MagicMock, patch
@@ -84,7 +84,11 @@ class TestClient(unittest.TestCase):
 
         mock_update_one.assert_called_once_with(
             {"_id": data_asset_record._id},
-            {"$set": data_asset_record.dict(by_alias=True)},
+            {
+                "$set": json.loads(
+                    data_asset_record.model_dump_json(by_alias=True)
+                )
+            },
             upsert=True,
         )
 
@@ -135,7 +139,7 @@ class TestClient(unittest.TestCase):
                     "$set": {
                         "_id": "abc-123",
                         "_name": "modal_00000_2000-10-10_10-10-10",
-                        "_created": datetime(2000, 10, 10, 10, 10, 10),
+                        "_created": "2000-10-10T10:10:10",
                         "_location": "some_url",
                         "subject": {"subject_id": "00000", "sex": "Female"},
                     }
@@ -151,7 +155,7 @@ class TestClient(unittest.TestCase):
                     "$set": {
                         "_id": "abc-125",
                         "_name": "modal_00001_2000-10-10_10-10-10",
-                        "_created": datetime(2000, 10, 10, 10, 10, 10),
+                        "_created": "2000-10-10T10:10:10",
                         "_location": "some_url",
                         "subject": {"subject_id": "00000", "sex": "Male"},
                     }

--- a/tests/test_secrets_access.py
+++ b/tests/test_secrets_access.py
@@ -99,3 +99,7 @@ class TestSecretAccess(unittest.TestCase):
         # Assert that ClientError is raised
         with self.assertRaises(ClientError):
             get_parameter("my_parameter")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #35 

 - Updates pydantic to v2
 - Imports pydantic_settings
 - Cleans up env vars
 - Imports aind-codeocean-api to re-use some code (see note below)

There are some useful classes in aind-codeocean-api that are used to set configs from aws Secrets Manager. It might make more sense to move those someplace more generic. Maybe in a utils module of aind-data-schema or some generic aind-data-configs package?

[class JsonConfigSettingsSource(PydanticBaseSettingsSource, ABC)](https://github.com/AllenNeuralDynamics/aind-codeocean-api/blob/4eff6794511eb5e580c4425b7a20239f0d3894ac/src/aind_codeocean_api/credentials.py#L21)
[class ConfigFileSettingsSource(JsonConfigSettingsSource)](https://github.com/AllenNeuralDynamics/aind-codeocean-api/blob/4eff6794511eb5e580c4425b7a20239f0d3894ac/src/aind_codeocean_api/credentials.py#L124)
[class AWSConfigSettingsSource(JsonConfigSettingsSource)](https://github.com/AllenNeuralDynamics/aind-codeocean-api/blob/4eff6794511eb5e580c4425b7a20239f0d3894ac/src/aind_codeocean_api/credentials.py#L134)