### PR TITLE
feat: adds delete method to api

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "aind-data-access-api"
 description = "API to interact with a few AIND databases"
 license = {text = "MIT"}
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
     {name = "Allen Institute for Neural Dynamics"}
 ]
@@ -58,7 +58,7 @@ version = {attr = "aind_data_access_api.__version__"}
 
 [tool.black]
 line-length = 79
-target_version = ['py36']
+target_version = ['py38']
 exclude = '''
 
 (


### PR DESCRIPTION
Closes #37 

 - Adds method to delete one record from docdb
 - Adds method to delete many records from docdb
 - Adds convenient wrapper to MetadataClient
 - Updates to min python version to 3.8
 - Stores Session object as cached property
 - Updates unit tests