### PR TITLE
Fix: upgrade SqlAlchemy for compatibility issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,8 @@ docdb = [
 ]
 rds = [
     "psycopg2-binary==2.9.5",
-    "pandas>=2.0.0",
-    "SQLAlchemy>=2.0.0"
+    "pandas>=2.0.0,<2.2.0",
+    "SQLAlchemy==1.4.49"
 ]
 full = [
     "aind-data-access-api[secrets]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ docdb = [
 rds = [
     "psycopg2-binary==2.9.5",
     "pandas>=2.0.0",
-    "SQLAlchemy==1.4.49"
+    "SQLAlchemy>=2.0.0"
 ]
 full = [
     "aind-data-access-api[secrets]",

--- a/src/aind_data_access_api/credentials.py
+++ b/src/aind_data_access_api/credentials.py
@@ -23,7 +23,7 @@ class CoreCredentials(BaseSettings):
     password: SecretStr = Field(...)
     host: str = Field(...)
     port: int = Field(...)
-    database: str = Field(...)
+    database: Optional[str] = Field(default=None)
 
     @classmethod
     def settings_customise_sources(

--- a/src/aind_data_access_api/rds_tables.py
+++ b/src/aind_data_access_api/rds_tables.py
@@ -28,7 +28,7 @@ class RDSCredentials(CoreCredentials):
     port: int = Field(default=5432)
     dbname: Optional[str] = Field(default=None)
 
-    @model_validator(mode='after')
+    @model_validator(mode="after")
     def validate_database_name(self) -> Self:
         """Sets database to db_name"""
         if self.database is None and self.dbname is None:

--- a/tests/test_rds_tables.py
+++ b/tests/test_rds_tables.py
@@ -9,6 +9,39 @@ from sqlalchemy import text
 from aind_data_access_api.rds_tables import Client, RDSCredentials
 
 
+class TestRDSCredentials(unittest.TestCase):
+    """Tests RDSCredentials class"""
+
+    def test_validate_database_name(self):
+        """Tests that database is set from dbname as expected."""
+        creds = RDSCredentials(
+            username="user",
+            password="password",
+            host="localhost",
+            port=5432,
+            dbname="test_db",
+        )
+        self.assertEqual(creds.database, "test_db")
+
+        creds2 = RDSCredentials(
+            username="user",
+            password="password",
+            host="localhost",
+            port=5432,
+            database="test_db",
+        )
+        self.assertEqual(creds2.database, "test_db")
+        self.assertIsNone(creds2.dbname)
+
+        with self.assertRaises(ValueError):
+            RDSCredentials(
+                username="user",
+                password="password",
+                host="localhost",
+                port=5432,
+            )
+
+
 class TestClient(unittest.TestCase):
     """Tests methods in the Client class."""
 


### PR DESCRIPTION
closes #39 

Pandas 2.2 and onwards no longer support SQLAlchemy 1.4. This PR puts a maximum limit on Pandas for now. Also adds a validator for db name so that database=dbname