### PR TITLE
docs: add docdb interface and utils usage to readthedocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,112 +4,13 @@
 ![Code Style](https://img.shields.io/badge/code%20style-black-black)
 [![semantic-release: angular](https://img.shields.io/badge/semantic--release-angular-e10079?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
 
-API to interact with a few AIND databases.
+API to interact with a few AIND databases. We have two primary databases:
 
-## Usage
-We have two primary databases. A Document store to keep unstructured json documents, and a relational database to store structured tables.
+1. A document database (DocDB) to store
+   unstructured json documents. The DocDB contains AIND metadata.
+2. A relational database to store structured tables.
 
-### Document Store
-We have some convenience methods to interact with our Document Store. You can create a client by explicitly setting credentials, or downloading from AWS Secrets Manager.
-
-__To connect from outside of our VPC:__
-
-1. If using credentials from environment, please configure:
-```sh
-DOC_DB_HOST=docdb-us-west-2-****.cluster-************.us-west-2.docdb.amazonaws.com
-DOC_DB_USERNAME=doc_db_username
-DOC_DB_PASSWORD=doc_db_password
-DOC_DB_SSH_HOST=ssh_host
-DOC_DB_SSH_USERNAME=ssh_username
-DOC_DB_SSH_PASSWORD=ssh_password
-```
-2. Usage:
-```python
-from aind_data_access_api.document_db_ssh import DocumentDbSSHClient, DocumentDbSSHCredentials
-
-# Method 1) if credentials are set in environment
-credentials = DocumentDbSSHCredentials()
-
-# Method 2) if you have permissions to AWS Secrets Manager
-# Each secret must contain corresponding "host", "username", and "password"
-credentials = DocumentDbSSHCredentials.from_secrets_manager(
-    doc_db_secret_name="/doc/store/secret/name", ssh_secret_name="/ssh/tunnel/secret/name"
-)
-
-with DocumentDbSSHClient(credentials=credentials) as doc_db_client:
-    # To get a list of filtered records:
-    filter = {"subject.subject_id": "123456"}
-    projection = {
-        "name": 1, "created": 1, "location": 1, "subject.subject_id": 1, "subject.date_of_birth": 1,
-    }
-    count = doc_db_client.collection.count_documents(filter)
-    response = list(doc_db_client.collection.find(filter=filter, projection=projection))
-```
-
-__To connect from within our VPC:__
-```python
-from aind_data_access_api.credentials import DocumentStoreCredentials
-from aind_data_access_api.document_store import Client
-
-# Method one assuming user, password, and host are known
-ds_client = Client(
-            credentials=DocumentStoreCredentials(
-                username="user",
-                password="password",
-                host="host",
-                database="metadata",
-            ),
-            collection_name="data_assets",
-        )
-
-# Method two if you have permissions to AWS Secrets Manager
-ds_client = Client(
-            credentials=DocumentStoreCredentials(
-                aws_secrets_name="aind/data/access/api/document_store/metadata"
-            ),
-            collection_name="data_assets",
-        )
-
-# To get all records
-response = list(ds_client.retrieve_data_asset_records())
-
-# To get a list of filtered records:
-response = list(ds_client.retrieve_data_asset_records({"subject.subject_id": "123456"}))
-```
-
-### RDS Tables
-We have some convenience methods to interact with our Relational Database. You can create a client by explicitly setting credentials, or downloading from AWS Secrets Manager.
-```
-from aind_data_access_api.credentials import RDSCredentials
-from aind_data_access_api.rds_tables import Client
-
-# Method one assuming user, password, and host are known
-ds_client = Client(
-            credentials=RDSCredentials(
-                username="user",
-                password="password",
-                host="host",
-                database="metadata",
-            ),
-            collection_name="data_assets",
-        )
-
-# Method two if you have permissions to AWS Secrets Manager
-ds_client = Client(
-            credentials=RDSCredentials(
-                aws_secrets_name="aind/data/access/api/rds_tables"
-            ),
-        )
-
-# To retrieve a table as a pandas dataframe
-df = ds_client.read_table(table_name="spike_sorting_urls")
-
-# Can also pass in a custom sql query
-df = ds_client.read_table(query="SELECT * FROM spike_sorting_urls")
-
-# It's also possible to save a pandas dataframe as a table. Please check internal documentation for more details.
-ds_client.overwrite_table_with_df(df, table_name)
-```
+More information can be found at [readthedocs](https://aind-data-access-api.readthedocs.io).
 
 ## Installation
 To use the software, it can be installed from PyPI.

--- a/docs/source/ExamplesDocDBDirectConnection.rst
+++ b/docs/source/ExamplesDocDBDirectConnection.rst
@@ -270,7 +270,7 @@ functions to update records in DocDB.
           
   if __name__ == "__main__":
       credentials = DocumentDbSSHCredentials()    # credentials in environment
-      dryrun = True                               # TODO: get from settings
+      dryrun = True
       filter = {"location": {"$regex": ".*s3://codeocean-s3datasetsbucket.*"}}
       projection = None
       

--- a/docs/source/ExamplesDocDBDirectConnection.rst
+++ b/docs/source/ExamplesDocDBDirectConnection.rst
@@ -1,0 +1,293 @@
+Examples - DocDB Direct Connection
+==========
+
+This page provides examples for interact with the Document Database (DocDB)
+using the provided Python client.
+
+It is assumed that the required credentials are set in environment.
+Please refer to the User Guide for more details.
+
+
+Querying Metadata
+~~~~~~~~~~~~~~~~~~~~~~
+
+Count Example 1: Get # of records with a certain subject_id
+------------------
+
+.. code:: python
+
+  import json
+
+  from aind_data_access_api.document_db_ssh import (
+      DocumentDbSSHClient,
+      DocumentDbSSHCredentials,
+  )
+
+  credentials = DocumentDbSSHCredentials()
+  with DocumentDbSSHClient(credentials=credentials) as doc_db_client:
+      filter = {"subject.subject_id": "689418"}
+      count = doc_db_client.collection.count_documents(filter)
+      print(count)
+
+Filter Example 1: Get records with a certain subject_id
+------------------
+
+.. code:: python
+
+  with DocumentDbSSHClient(credentials=credentials) as doc_db_client:
+      filter = {"subject.subject_id": "689418"}
+      records = list(
+          doc_db_client.collection.find(filter=filter)
+      )
+      print(json.dumps(records, indent=3))
+
+
+With projection (recommended):
+      
+.. code:: python
+
+  with DocumentDbSSHClient(credentials=credentials) as doc_db_client:
+      filter = {"subject.subject_id": "689418"}
+      projection = {
+          "name": 1,
+          "created": 1,
+          "location": 1,
+          "subject.subject_id": 1,
+          "subject.date_of_birth": 1,
+      }
+      records = list(
+          doc_db_client.collection.find(filter=filter, projection=projection)
+      )
+      print(json.dumps(records, indent=3))
+
+
+Filter Example 2: Get records with a certain breeding group
+------------------
+
+.. code:: python
+
+  with DocumentDbSSHClient(credentials=credentials) as doc_db_client:
+      filter = {
+          "subject.breeding_info.breeding_group": "Chat-IRES-Cre_Jax006410"
+      }
+      records = list(
+          doc_db_client.collection.find(filter=filter)
+      )
+      print(json.dumps(records, indent=3))
+
+
+With projection (recommended):
+
+.. code:: python
+
+  with DocumentDbSSHClient(credentials=credentials) as doc_db_client:
+      filter = {
+          "subject.breeding_info.breeding_group": "Chat-IRES-Cre_Jax006410"
+      }
+      projection = {
+          "name": 1,
+          "created": 1,
+          "location": 1,
+          "subject.subject_id": 1,
+          "subject.breeding_info.breeding_group": 1,
+      }
+      records = list(
+          doc_db_client.collection.find(filter=filter, projection=projection)
+      )
+      print(json.dumps(records, indent=3))
+
+Aggregation Example 1: Get all subjects per breeding group
+------------------
+
+.. code:: python
+
+  with DocumentDbSSHClient(credentials=credentials) as doc_db_client:
+      agg_pipeline = [
+          {
+              "$group": {
+                  "_id": "$subject.breeding_info.breeding_group",
+                  "subject_ids": {"$addToSet": "$subject.subject_id"},
+              }
+          }
+      ]
+      result = list(
+          doc_db_client.collection.aggregate(pipeline=agg_pipeline)
+      )
+      print(f"Total breeding groups: {len(result)}")
+      print(f"First 3 breeding groups and corresponding subjects:")
+      print(json.dumps(result[:3], indent=3))
+
+
+Updating Metadata
+~~~~~~~~~~~~~~~~~~~~~~
+
+We provide several utility functions for interacting with DocDB within the
+``aind_data_access_api.utils`` module. Below is an example of how to use these
+functions to update records in DocDB.
+
+.. code:: python
+
+  import json
+  import logging
+  from typing import List, Optional
+
+  from aind_data_access_api.document_db_ssh import (
+      DocumentDbSSHClient,
+      DocumentDbSSHCredentials,
+  )
+  from aind_data_schema.core.metadata import Metadata
+
+  from aind_data_access_api.utils import paginate_docdb, is_dict_corrupt
+
+  logging.basicConfig(level="INFO")
+
+  def _process_docdb_records(records: List[dict], doc_db_client: DocumentDbSSHClient, dryrun: bool) -> None:
+      """
+      Process records.
+      Parameters
+      ----------
+      records : List[dict]
+
+      """
+      for record in records:
+          _process_docdb_record(record=record, doc_db_client=doc_db_client, dryrun=dryrun)
+
+  def _process_docdb_record(record: dict, doc_db_client: DocumentDbSSHClient, dryrun: bool) -> None:
+      """
+      Process record. This example updates the data_description.name field
+      if it does not match the record.name field.
+
+      Parameters
+      ----------
+      record : dict
+
+      """
+      _id = record.get("_id")
+      name = record.get("name")
+      location = record.get("location")
+      if _id:
+          if record.get("data_description") and record["data_description"].get("name") != name:
+              # Option 1: update specific fields(s) only
+              new_fields = {
+                  "data_description.name": name
+              }
+              update_docdb_record_partial(record_id=_id, new_fields=new_fields, doc_db_client=doc_db_client, dryrun=dryrun)
+              # Option 2: build new record Metadata.py and replace entire document with new record
+              # new_record = build_new_docdb_record(record=record)
+              # if new_record is not None:
+              #     update_docdb_record_entire(record_id=_id, new_record=new_record, doc_db_client=doc_db_client, dryrun=dryrun)
+          # else:
+          #     logging.info(f"Record for {location} does not need to be updated.")
+      else:
+          logging.warning(f"Record for {location} does not have an _id field! Skipping.")
+
+
+  def build_new_docdb_record(record: Optional[dict]) -> Optional[dict]:
+      """Build new record from existing record. This example updates the
+      data_description.name field if it does not match the record.name field.
+
+      Parameters
+      ----------
+      record : Optional[dict]
+
+      Returns
+      -------
+      Optional[dict]
+          The new record, or None if the record cannot be constructed.
+      """
+      # Example: Update record.data_description.name if not matching record.name
+      new_record = None
+      if record.get("data_description") and record["data_description"].get("name") != name:
+          _id = record.get("_id")
+          name = record.get("name")
+          location = record.get("location")
+          created = record.get("created")
+          if _id is None or name is None or location is None or created is None:
+              logging.warning(f"Record does not have _id, name, location, or created! Skipping.")
+              return None
+          try:
+              new_record = record.copy()
+              new_record["data_description"]["name"] = name
+              new_record_str = Metadata.model_construct(
+                  **new_record
+              ).model_dump_json(warnings=False, by_alias=True)
+              new_record = json.loads(new_record_str)
+              if is_dict_corrupt(new_record):
+                  logging.warning(f"New record for {location} is corrupt! Skipping.")
+                  new_record = None
+          except Exception:
+              new_record = None
+      return new_record
+
+  def update_docdb_record_partial(record_id: str, new_fields: dict, doc_db_client: DocumentDbSSHClient, dryrun: bool) -> None:
+      """
+      Update record in docdb by updating specific fields only.
+      Parameters
+      ----------
+      record_id : str
+          The _id of the record to update.
+      new_fields : dict
+          New fields to update. E.g. {"data_description.name": "new_name"}
+
+      """
+      if dryrun:
+          logging.info(f"(dryrun) doc_db_client.collection.update_one (partial): {record_id}")
+      else:
+          logging.info(f"doc_db_client.collection.update_one (partial): {record_id}")
+          response = doc_db_client.collection.update_one(
+              {"_id": record_id},
+              {"$set": new_fields},
+              upsert=False,
+          )
+          logging.info(response.raw_result)
+
+
+  def update_docdb_record_entire(record_id: str, new_record: dict, doc_db_client: DocumentDbSSHClient, dryrun: bool) -> None:
+      """
+      Update record in docdb by replacing the entire document with new record.
+      Parameters
+      ----------
+      record_id : str
+          The _id of the record to update.
+      new_record : dict
+          The new record to replace the existing record with.
+
+      """
+      if is_dict_corrupt(new_record) or record_id != new_record.get("_id"):
+          logging.warning(f"Attempting to update corrupt record {record_id}! Skipping.")
+          return
+      if dryrun:
+          logging.info(f"(dryrun) doc_db_client.collection.update_one: {record_id}")
+      else:
+          logging.info(f"doc_db_client.collection.update_one: {record_id}")
+          response = doc_db_client.collection.update_one(
+              {"_id": record_id},
+              {"$set": new_record},
+              upsert=False,
+          )
+          logging.info(response.raw_result)
+            
+          
+  if __name__ == "__main__":
+      credentials = DocumentDbSSHCredentials()    # credentials in environment
+      dryrun = True                               # TODO: get from settings
+      filter = {"location": {"$regex": ".*s3://codeocean-s3datasetsbucket.*"}}
+      projection = None
+      
+      with DocumentDbSSHClient(credentials=credentials) as doc_db_client:
+          db_name = doc_db_client.database_name
+          col_name = doc_db_client.collection_name
+          # count = doc_db_client.collection.count_documents(filter)
+          # logging.info(f"{db_name}.{col_name}: Found {count} records with {filter}: {count}")
+
+          logging.info(f"{db_name}.{col_name}: Starting to scan for {filter}.")
+          docdb_pages = paginate_docdb(
+              db_name=doc_db_client.database_name,
+              collection_name=doc_db_client.collection_name,
+              docdb_client=doc_db_client._client,
+              page_size=500,
+              filter_query=filter,
+          )
+          for page in docdb_pages:
+              _process_docdb_records(records=page, doc_db_client=doc_db_client, dryrun=dryrun)
+          logging.info(f"{db_name}.{col_name}:Finished scanning through DocDb.")

--- a/docs/source/UserGuide.rst
+++ b/docs/source/UserGuide.rst
@@ -3,19 +3,32 @@ User Guide
 
 Thank you for using ``aind-data-access-api``! This guide is
 intended for scientists and engineers in AIND that wish to interface
-with AIND Metadata.
+with AIND databases.
 
 We have two primary databases:
-1. A document database (DocDB) to keep unstructured json documents. The DocDB contains AIND metadata.
-2. A relational database to store structured tables.
+
+1. A `document database (DocDB) <#document-database-docdb>`__ to store
+   unstructured json documents. The DocDB contains AIND metadata.
+2. A `relational database <#rds-tables>`__ to store structured tables.
 
 Document Database (DocDB)
 --------------------
 
-- If using the REST API (Read-Only), you do not need credentials.
-- If using any of the Direct Connection (SSH) methods, it is assumed that you have DocDB and
-  SSH credentials (or have access to AWS Secrets Manager).
+AIND metadata records stored in the DocDB describe the ``metadata.nd.json``
+for a data asset:
 
+- ``_id``: the unique ID of the data asset.
+- ``name``: the name of the data asset.
+- ``location``: the S3 location of the metadata, in the format
+  ``s3://{bucket_name}/{name}``. This is unique across records and can
+  be used to query or identify specific records.
+- Please see the `readthedocs for aind-data-schema 
+  <https://aind-data-schema.readthedocs.io/en/latest/aind_data_schema.core.html#module-aind_data_schema.core.metadata>`__
+  for more details.
+
+The DocDB can be accessed through a public read-only REST API or
+through a direct connection using SSH. For a direct connection,
+it is assumed you have the appropriate credentials.
 
 REST API (Read-Only)
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -133,18 +146,18 @@ Direct Connection (SSH) - Python Client
 We have some convenience methods to interact with our Document Store.
 You can create a client by explicitly setting credentials, or downloading from AWS Secrets Manager.
 
-1. If using credentials from environment, please configure:
+If using credentials from environment, please configure:
 
 .. code:: bash
 
-   DOC_DB_HOST=docdb-us-west-2-****.cluster-************.us-west-2.docdb.amazonaws.com
+   DOC_DB_HOST=************.us-west-2.docdb.amazonaws.com
    DOC_DB_USERNAME=doc_db_username
    DOC_DB_PASSWORD=doc_db_password
    DOC_DB_SSH_HOST=ssh_host
    DOC_DB_SSH_USERNAME=ssh_username
    DOC_DB_SSH_PASSWORD=ssh_password
 
-2. Usage:
+To use the client:
 
 .. code:: python
 

--- a/docs/source/UserGuide.rst
+++ b/docs/source/UserGuide.rst
@@ -1,0 +1,113 @@
+User Guide
+==========
+
+Thank you for using ``aind-data-access-api``! This guide is
+intended for scientists and engineers in AIND that wish to interface
+with AIND Metadata.
+
+We have two primary databases:
+1. A document database (DocDB) to keep unstructured json documents. The DocDB contains AIND metadata.
+2. A relational database to store structured tables.
+
+Document Database (DocDB)
+--------------------
+
+- If using the REST API (Read-Only), you do not need credentials.
+- If using any of the Direct Connection (SSH) methods, it is assumed that you have DocDB and
+  SSH credentials (or have access to AWS Secrets Manager).
+
+
+REST API (Read-Only)
+~~~~~~~~~~~~~~~~~~~~~~
+- TODO
+
+
+Direct Connection (SSH) - Database UI (MongoDB Compass)
+~~~~~~~~~~~~~~~~~~~~~~
+- TODO
+
+
+Direct Connection (SSH) - Python Client
+~~~~~~~~~~~~~~~~~~~~~~
+
+We have some convenience methods to interact with our Document Store.
+You can create a client by explicitly setting credentials, or downloading from AWS Secrets Manager.
+
+1. If using credentials from environment, please configure:
+
+.. code:: bash
+
+   DOC_DB_HOST=docdb-us-west-2-****.cluster-************.us-west-2.docdb.amazonaws.com
+   DOC_DB_USERNAME=doc_db_username
+   DOC_DB_PASSWORD=doc_db_password
+   DOC_DB_SSH_HOST=ssh_host
+   DOC_DB_SSH_USERNAME=ssh_username
+   DOC_DB_SSH_PASSWORD=ssh_password
+
+2. Usage:
+
+.. code:: python
+
+   from aind_data_access_api.document_db_ssh import DocumentDbSSHClient, DocumentDbSSHCredentials
+
+   # Method 1) if credentials are set in environment
+   credentials = DocumentDbSSHCredentials()
+
+   # Method 2) if you have permissions to AWS Secrets Manager
+   # Each secret must contain corresponding "host", "username", and "password"
+   credentials = DocumentDbSSHCredentials.from_secrets_manager(
+      doc_db_secret_name="/doc/db/secret/name", ssh_secret_name="/ssh/tunnel/secret/name"
+   )
+
+   with DocumentDbSSHClient(credentials=credentials) as doc_db_client:
+      # To get a list of filtered records:
+      filter = {"subject.subject_id": "123456"}
+      projection = {
+         "name": 1, "created": 1, "location": 1, "subject.subject_id": 1, "subject.date_of_birth": 1,
+      }
+      count = doc_db_client.collection.count_documents(filter)
+      response = list(doc_db_client.collection.find(filter=filter, projection=projection))
+
+
+RDS Tables
+------------------
+We have some convenience methods to interact with our Relational Database. You can create a client by 
+explicitly setting credentials, or downloading from AWS Secrets Manager.
+
+.. code:: python
+
+   from aind_data_access_api.credentials import RDSCredentials
+   from aind_data_access_api.rds_tables import Client
+
+   # Method one assuming user, password, and host are known
+   ds_client = Client(
+               credentials=RDSCredentials(
+                  username="user",
+                  password="password",
+                  host="host",
+                  database="metadata",
+               ),
+               collection_name="data_assets",
+         )
+
+   # Method two if you have permissions to AWS Secrets Manager
+   ds_client = Client(
+               credentials=RDSCredentials(
+                  aws_secrets_name="aind/data/access/api/rds_tables"
+               ),
+         )
+
+   # To retrieve a table as a pandas dataframe
+   df = ds_client.read_table(table_name="spike_sorting_urls")
+
+   # Can also pass in a custom sql query
+   df = ds_client.read_table(query="SELECT * FROM spike_sorting_urls")
+
+   # It's also possible to save a pandas dataframe as a table. Please check internal documentation for more details.
+   ds_client.overwrite_table_with_df(df, table_name)
+
+Reporting bugs or making feature requests
+-----------------------------------------
+
+Please report any bugs or feature requests here:
+`issues <https://github.com/AllenNeuralDynamics/aind-data-access-api/issues/new/choose>`__

--- a/docs/source/UserGuide.rst
+++ b/docs/source/UserGuide.rst
@@ -63,8 +63,69 @@ REST API (Read-Only)
 
 Direct Connection (SSH) - Database UI (MongoDB Compass)
 ~~~~~~~~~~~~~~~~~~~~~~
-- TODO
 
+MongoDB Compass is a database GUI that can be used to query and interact
+with our document database.
+
+To connect:
+
+1. If provided a temporary SSH password, please first run ``ssh {ssh-username}@54.184.81.236``
+   and set a new password.
+2. Download the full version of `MongoDB Compass <https://www.mongodb.com/try/download/compass>`__.
+3. When connecting, click “Advanced Connection Options” and use the configurations below.
+   Leave any unspecified fields on their default setting.
+
+.. list-table::
+   :widths: 25 25 50
+   :header-rows: 1
+
+   * - Tab
+     - Config
+     - Value
+   * - General
+     - Host
+     - ``************.us-west-2.docdb.amazonaws.com``
+   * - Authentication
+     - Username
+     - ``doc_db_username``
+   * - 
+     - Password
+     - ``doc_db_password``
+   * - 
+     - Authentication Mechanism
+     - SCRAM-SHA-1
+   * - TLS/SSL
+     - SSL/TLS Connection
+     - OFF
+   * - Proxy/SSH
+     - SSH Tunnel/ Proxy Method	
+     - SSH with Password
+   * -
+     - SSH Hostname
+     - ``ssh_host``
+   * -
+     - SSH Port
+     - 22
+   * -
+     - SSH Username
+     - ``ssh_username``
+   * -
+     - SSH Username
+     - ``ssh_password``
+   
+4. You should be able to see the home page with the ``metadata-index`` database.
+   It should have 1 single collection called ``data_assets``.
+5. If provided with a temporary DocDB password, please change it using the embedded
+   mongo shell in Compass, and then reconnect.
+
+.. code:: bash
+   
+   db.updateUser(
+      "doc_db_username",
+      {
+         pwd: passwordPrompt()
+      }
+   )
 
 Direct Connection (SSH) - Python Client
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/UserGuide.rst
+++ b/docs/source/UserGuide.rst
@@ -19,7 +19,46 @@ Document Database (DocDB)
 
 REST API (Read-Only)
 ~~~~~~~~~~~~~~~~~~~~~~
-- TODO
+
+1. A GET request to ``https://api.allenneuraldynamics.org/v1/metadata_index/data_assets``
+   with appropriate query parameters will return a list of records found.
+
+.. code:: python
+
+   import json
+   import requests
+
+   URL = "https://api.allenneuraldynamics.org/v1/metadata_index/data_assets"
+   filter = {"subject.subject_id": "123456"}
+   limit = 100
+   response = requests.get(URL, params={"filter": json.dumps(filter), "limit": limit})
+   print(response.json())
+
+2. Alternatively, we provide a Python client:
+
+.. code:: python
+
+   from aind_data_access_api.document_db import MetadataDbClient
+
+   API_GATEWAY_HOST = "api.allenneuraldynamics.org"
+   DATABASE = "metadata_index"
+   COLLECTION = "data_assets"
+
+   docdb_api_client = MetadataDbClient(
+      host=API_GATEWAY_HOST,
+      database=DATABASE,
+      collection=COLLECTION,
+   )
+
+   filter = {"subject.subject_id": "123456"}
+   limit = 1000
+   paginate_batch_size = 100
+   response = docdb_api_client.retrieve_data_asset_records(
+      filter_query=filter,
+      limit=limit,
+      paginate_batch_size=paginate_batch_size
+   )
+   print(response)
 
 
 Direct Connection (SSH) - Database UI (MongoDB Compass)

--- a/docs/source/aind_data_access_api.rst
+++ b/docs/source/aind_data_access_api.rst
@@ -60,6 +60,14 @@ aind\_data\_access\_api.secrets module
    :undoc-members:
    :show-inheritance:
 
+aind\_data\_access\_api.utils module
+------------------------------------
+
+.. automodule:: aind_data_access_api.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Module contents
 ---------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,7 @@ Welcome to this repository's documentation!
    :caption: Contents:
 
    UserGuide
+   ExamplesDocDBDirectConnection
    modules
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,7 @@ Welcome to this repository's documentation!
    :maxdepth: 2
    :caption: Contents:
 
+   UserGuide
    modules
 
 


### PR DESCRIPTION
closes #49 

Readthedocs updates:
- Move Usage docs (for DocDBSSH and RDS clients) from readme to User Guide page
- Add usage docs for the REST API client and Mongo Compass
- Add `DocumentDbSSHClient` examples (show examples w/o projections first)
- Enable automodule for `aind_data_access_api.utils` docs

A future ticket will address adding Contributing.rst; once done, remaining sections of the README can be removed.