### PR TITLE
feat: do not convert docdb records to DataAssetRecord

### DIFF
--- a/docs/source/UserGuide.rst
+++ b/docs/source/UserGuide.rst
@@ -66,7 +66,7 @@ REST API (Read-Only)
    filter = {"subject.subject_id": "123456"}
    limit = 1000
    paginate_batch_size = 100
-   response = docdb_api_client.retrieve_data_asset_records(
+   response = docdb_api_client.retrieve_docdb_records(
       filter_query=filter,
       limit=limit,
       paginate_batch_size=paginate_batch_size

--- a/src/aind_data_access_api/document_db.py
+++ b/src/aind_data_access_api/document_db.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import warnings
 from functools import cached_property
 from sys import getsizeof
 from typing import List, Optional, Tuple
@@ -316,7 +317,7 @@ class MetadataDbClient(Client):
                     )
         return records
 
-    # TODO: deprecate this method
+    # TODO: remove this method
     def retrieve_data_asset_records(
         self,
         filter_query: Optional[dict] = None,
@@ -328,6 +329,9 @@ class MetadataDbClient(Client):
         paginate_max_iterations: int = 20000,
     ) -> List[DataAssetRecord]:
         """
+        DEPRECATED: This method is deprecated. Use `retrieve_docdb_records`
+        instead.
+
         Retrieve data asset records
 
         Parameters
@@ -355,6 +359,13 @@ class MetadataDbClient(Client):
         List[DataAssetRecord]
 
         """
+        warnings.warn(
+            "retrieve_data_asset_records is deprecated. "
+            "Use retrieve_docdb_records instead."
+            "",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if paginate is False:
             records = self._get_records(
                 filter_query=filter_query,
@@ -421,12 +432,23 @@ class MetadataDbClient(Client):
         )
         return response
 
-    # TODO: deprecate this method
+    # TODO: remove this method
     def upsert_one_record(
         self, data_asset_record: DataAssetRecord
     ) -> Response:
-        """Upsert one record"""
+        """
+        DEPRECATED: This method is deprecated. Use `upsert_one_docdb_record`
+        instead.
 
+        Upsert one record
+        """
+        warnings.warn(
+            "upsert_one_record is deprecated. "
+            "Use upsert_one_docdb_record instead."
+            "",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         response = self._upsert_one_record(
             record_filter={"_id": data_asset_record.id},
             update={
@@ -548,13 +570,16 @@ class MetadataDbClient(Client):
                 second_index = second_index + 1
         return responses
 
-    # TODO: deprecate this method
+    # TODO: remove this method
     def upsert_list_of_records(
         self,
         data_asset_records: List[DataAssetRecord],
         max_payload_size: int = 2e6,
     ) -> List[Response]:
         """
+        DEPRECATED: This method is deprecated. Use
+        `upsert_list_of_docdb_records` instead.
+
         Upsert a list of records. There's a limit to the size of the
         request that can be sent, so we chunk the requests.
 
@@ -576,6 +601,13 @@ class MetadataDbClient(Client):
           A list of responses from the API Gateway.
 
         """
+        warnings.warn(
+            "upsert_list_of_records is deprecated. "
+            "Use upsert_list_of_docdb_records instead."
+            "",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if len(data_asset_records) == 0:
             return []
         else:

--- a/src/aind_data_access_api/document_db_ssh.py
+++ b/src/aind_data_access_api/document_db_ssh.py
@@ -69,6 +69,9 @@ class DocumentDbSSHCredentials(CoreCredentials):
 class DocumentDbSSHClient:
     """Class to establish a Document Store client with SSH tunneling."""
 
+    # TODO: add retrieve_docdb_records, upsert_one_docdb_record,
+    # and upsert_list_of_docdb_records methods
+
     def __init__(self, credentials: DocumentDbSSHCredentials):
         """
         Construct a client to interface with a Document Database.

--- a/src/aind_data_access_api/document_store.py
+++ b/src/aind_data_access_api/document_store.py
@@ -12,6 +12,7 @@ from aind_data_access_api.credentials import CoreCredentials
 from aind_data_access_api.models import DataAssetRecord
 
 
+# TODO: deprecate this class
 class DocumentStoreCredentials(CoreCredentials):
     """Document Store credentials"""
 
@@ -31,6 +32,7 @@ class DocumentStoreCredentials(CoreCredentials):
     database: str = Field(...)
 
 
+# TODO: deprecate this client
 class Client:
     """Class to establish a document store client."""
 

--- a/src/aind_data_access_api/models.py
+++ b/src/aind_data_access_api/models.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from pydantic import BaseModel, Extra, Field
 
 
-# TODO: deprecate this model
+# TODO: remove this model
 class DataAssetRecord(BaseModel):
     """The records in the Data Asset Collection needs to contain certain fields
     to easily query and index the data."""

--- a/src/aind_data_access_api/models.py
+++ b/src/aind_data_access_api/models.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from pydantic import BaseModel, Extra, Field
 
 
+# TODO: deprecate this model
 class DataAssetRecord(BaseModel):
     """The records in the Data Asset Collection needs to contain certain fields
     to easily query and index the data."""

--- a/tests/test_document_db.py
+++ b/tests/test_document_db.py
@@ -323,7 +323,7 @@ class TestMetadataDbClient(unittest.TestCase):
         )
         self.assertEqual(expected_response, records)
 
-    # TODO: Deprecate this test
+    # TODO: remove this test
     @patch("aind_data_access_api.document_db.Client._get_records")
     @patch("aind_data_access_api.document_db.Client._count_records")
     def test_retrieve_data_asset_records(
@@ -361,7 +361,7 @@ class TestMetadataDbClient(unittest.TestCase):
         self.assertEqual(expected_response, list(records))
         self.assertEqual(expected_response, list(paginate_records))
 
-    # TODO: Deprecate this test
+    # TODO: remove this test
     @patch("aind_data_access_api.document_db.Client._get_records")
     @patch("aind_data_access_api.document_db.Client._count_records")
     @patch("logging.error")
@@ -459,7 +459,7 @@ class TestMetadataDbClient(unittest.TestCase):
         )
         mock_upsert.assert_not_called()
 
-    # TODO: Deprecate this test
+    # TODO: remove this test
     @patch("aind_data_access_api.document_db.Client._upsert_one_record")
     def test_upsert_one_record(self, mock_upsert: MagicMock):
         """Tests upserting one data asset record"""
@@ -665,7 +665,7 @@ class TestMetadataDbClient(unittest.TestCase):
         )
         mock_bulk_write.assert_not_called()
 
-    # TODO: Deprecate this test
+    # TODO: remove this test
     @patch("aind_data_access_api.document_db.Client._bulk_write")
     def test_upsert_list_of_records(self, mock_bulk_write: MagicMock):
         """Tests upserting a list of data asset records"""
@@ -728,7 +728,7 @@ class TestMetadataDbClient(unittest.TestCase):
             ]
         )
 
-    # TODO: Deprecate this test
+    # TODO: remove this test
     @patch("aind_data_access_api.document_db.Client._bulk_write")
     def test_upsert_empty_list_of_records(self, mock_bulk_write: MagicMock):
         """Tests upserting an empty list of data asset records"""
@@ -740,7 +740,7 @@ class TestMetadataDbClient(unittest.TestCase):
         self.assertEqual([], response)
         mock_bulk_write.assert_not_called()
 
-    # TODO: Deprecate this test
+    # TODO: remove this test
     @patch("aind_data_access_api.document_db.Client._bulk_write")
     def test_upsert_chunked_list_of_records(self, mock_bulk_write: MagicMock):
         """Tests upserting a list of data asset records in chunks"""


### PR DESCRIPTION
closes #61 

`MetadataDbClient` for rest api:
- added retrieve and upsert methods that read/write raw records to docdb
- added deprecation warnings for methods that use `DataAssetRecord`
- updated User Guide example