### PR TITLE
feat: support aggregations in docdb rest api

### DIFF
--- a/docs/source/ExamplesDocDBDirectConnection.rst
+++ b/docs/source/ExamplesDocDBDirectConnection.rst
@@ -107,6 +107,7 @@ Aggregation Example 1: Get all subjects per breeding group
               "$group": {
                   "_id": "$subject.breeding_info.breeding_group",
                   "subject_ids": {"$addToSet": "$subject.subject_id"},
+                  "count": {"$sum": 1},
               }
           }
       ]
@@ -116,6 +117,9 @@ Aggregation Example 1: Get all subjects per breeding group
       print(f"Total breeding groups: {len(result)}")
       print(f"First 3 breeding groups and corresponding subjects:")
       print(json.dumps(result[:3], indent=3))
+
+For more info about aggregations, please see MongoDB documentation:
+https://www.mongodb.com/docs/manual/aggregation/
 
 
 Updating Metadata

--- a/docs/source/ExamplesDocDBRestApi.rst
+++ b/docs/source/ExamplesDocDBRestApi.rst
@@ -1,0 +1,123 @@
+Examples - DocDB REST API
+==================================
+
+This page provides examples for interact with the Document Database (DocDB)
+REST API using the provided Python client.
+
+
+Querying Metadata
+~~~~~~~~~~~~~~~~~~~~~~
+
+Count Example 1: Get # of records with a certain subject_id
+-----------------------------------------------------------
+
+.. code:: python
+
+  import json
+
+  from aind_data_access_api.document_db import MetadataDbClient
+
+  API_GATEWAY_HOST = "api.allenneuraldynamics.org"
+  DATABASE = "metadata_index"
+  COLLECTION = "data_assets"
+
+  docdb_api_client = MetadataDbClient(
+      host=API_GATEWAY_HOST,
+      database=DATABASE,
+      collection=COLLECTION,
+  )
+
+  filter = {"subject.subject_id": "689418"}
+  count = docdb_api_client._count_records(
+      filter_query=filter,
+  )
+  print(count)
+
+Filter Example 1: Get records with a certain subject_id
+-------------------------------------------------------
+
+.. code:: python
+
+  filter = {"subject.subject_id": "689418"}
+  records = docdb_api_client.retrieve_docdb_records(
+      filter_query=filter,
+  )
+  print(json.dumps(records, indent=3))
+
+
+With projection (recommended):
+      
+.. code:: python
+
+  filter = {"subject.subject_id": "689418"}
+  projection = {
+      "name": 1,
+      "created": 1,
+      "location": 1,
+      "subject.subject_id": 1,
+      "subject.date_of_birth": 1,
+  }
+  records = docdb_api_client.retrieve_docdb_records(
+      filter_query=filter,
+      projection=projection,
+  )
+  print(json.dumps(records, indent=3))
+
+
+Filter Example 2: Get records with a certain breeding group
+-----------------------------------------------------------
+
+.. code:: python
+
+  filter = {
+      "subject.breeding_info.breeding_group": "Chat-IRES-Cre_Jax006410"
+  }
+  records = docdb_api_client.retrieve_docdb_records(
+      filter_query=filter
+  )
+  print(json.dumps(records, indent=3))
+
+
+With projection (recommended):
+
+.. code:: python
+
+  filter = {
+      "subject.breeding_info.breeding_group": "Chat-IRES-Cre_Jax006410"
+  }
+  projection = {
+      "name": 1,
+      "created": 1,
+      "location": 1,
+      "subject.subject_id": 1,
+      "subject.breeding_info.breeding_group": 1,
+  }
+  records = docdb_api_client.retrieve_docdb_records(
+      filter_query=filter,
+      projection=projection,
+  )
+  print(json.dumps(records, indent=3))
+
+Aggregation Example 1: Get all subjects per breeding group
+----------------------------------------------------------
+
+.. code:: python
+
+  agg_pipeline = [
+      {
+          "$group": {
+              "_id": "$subject.breeding_info.breeding_group",
+              "subject_ids": {"$addToSet": "$subject.subject_id"},
+              "count": {"$sum": 1},
+          }
+    }
+  ]
+  result = docdb_api_client.aggregate_docdb_records(
+      pipeline=agg_pipeline
+  )
+  print(f"Total breeding groups: {len(result)}")
+  print(f"First 3 breeding groups and corresponding subjects:")
+  print(json.dumps(result[:3], indent=3))
+
+For more info about aggregations, please see MongoDB documentation:
+https://www.mongodb.com/docs/manual/aggregation/

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,7 @@ Welcome to this repository's documentation!
    :caption: Contents:
 
    UserGuide
+   ExamplesDocDBRestApi
    ExamplesDocDBDirectConnection
    Contributing
    modules

--- a/tests/test_document_db.py
+++ b/tests/test_document_db.py
@@ -507,6 +507,27 @@ class TestMetadataDbClient(unittest.TestCase):
         )
         self.assertEqual(expected_response, list(records))
 
+    @patch("aind_data_access_api.document_db.Client._aggregate_records")
+    def test_aggregate_docdb_records(self, mock_aggregate: MagicMock):
+        """Tests aggregating docdb records"""
+        expected_result = [
+            {
+                "_id": "abc-123",
+                "name": "modal_00000_2000-10-10_10-10-10",
+                "created": datetime(2000, 10, 10, 10, 10, 10),
+                "location": "some_url",
+                "subject": {"subject_id": "00000", "sex": "Female"},
+            }
+        ]
+        client = MetadataDbClient(**self.example_client_args)
+        mock_aggregate.return_value = expected_result
+        pipeline = [{"$match": {"_id": "abc-123"}}]
+        result = client.aggregate_docdb_records(pipeline)
+        self.assertEqual(result, expected_result)
+        mock_aggregate.assert_called_once_with(
+            pipeline=pipeline,
+        )
+
     @patch("aind_data_access_api.document_db.Client._upsert_one_record")
     def test_upsert_one_docdb_record(self, mock_upsert: MagicMock):
         """Tests upserting one docdb record"""

--- a/tests/test_document_db.py
+++ b/tests/test_document_db.py
@@ -175,7 +175,9 @@ class TestClient(unittest.TestCase):
         mock_error = {
             "error": {
                 "name": "MongoServerError",
-                "message": "Unrecognized pipeline stage name: '$match_invalid'",
+                "message": (
+                    "Unrecognized pipeline stage name: '$match_invalid'"
+                ),
             }
         }
         mock_response1._content = json.dumps(mock_error).encode("utf-8")

--- a/tests/test_document_db.py
+++ b/tests/test_document_db.py
@@ -146,6 +146,55 @@ class TestClient(unittest.TestCase):
             "ValueError('No payload in response')", repr(e.exception)
         )
 
+    @patch("requests.post")
+    def test_aggregate_records(self, mock_post: MagicMock):
+        """Tests _aggregate_records method"""
+        pipeline = [{"$match": {"_id": "abc123"}}]
+        client = Client(**self.example_client_args)
+        mock_response = Response()
+        mock_response.status_code = 200
+        mock_response._content = json.dumps(
+            [{"_id": "abc123", "message": "hi"}]
+        ).encode("utf-8")
+
+        mock_post.return_value = mock_response
+        result = client._aggregate_records(pipeline=pipeline)
+        self.assertEqual(
+            [{"_id": "abc123", "message": "hi"}],
+            result,
+        )
+
+    @patch("requests.post")
+    def test_aggregate_records_error(self, mock_post: MagicMock):
+        """Tests _aggregate_records method when there is an HTTP error or
+        no payload in response"""
+        invalid_pipeline = [{"$match_invalid": {"_id": "abc123"}}]
+        client = Client(**self.example_client_args)
+        mock_response1 = Response()
+        mock_response1.status_code = 400
+        mock_error = {
+            "error": {
+                "name": "MongoServerError",
+                "message": "Unrecognized pipeline stage name: '$match_invalid'",
+            }
+        }
+        mock_response1._content = json.dumps(mock_error).encode("utf-8")
+        mock_response2 = Response()
+        mock_response2.status_code = 200
+        mock_response2._content = None
+        mock_post.side_effect = [mock_response1, mock_response2]
+        with self.assertRaises(ValueError) as e:
+            client._aggregate_records(pipeline=invalid_pipeline)
+        self.assertEqual(
+            f"400 Error: {json.dumps(mock_error)}",
+            str(e.exception),
+        )
+        with self.assertRaises(ValueError) as e:
+            client._aggregate_records(pipeline=invalid_pipeline)
+        self.assertEqual(
+            "ValueError('No payload in response')", repr(e.exception)
+        )
+
     @patch("boto3.session.Session")
     @patch("botocore.auth.SigV4Auth.add_auth")
     @patch("requests.post")


### PR DESCRIPTION
closes #78
- Add `aggregate_docdb_records()` in `aind_data_access_api.document_db.MetadataDbClient`
- Add examples to readthedocs for docdb rest api to match ssh client examples