### PR TITLE
feat: get_id_from_name and get_name_from_id helpers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ source = ["aind_data_access_api", "tests"]
 [tool.coverage.report]
 exclude_lines = [
     "if __name__ == .__main__.:",
-    "from",
+    "from .* import .*",
     "import",
     "pragma: no cover"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,8 +86,8 @@ source = ["aind_data_access_api", "tests"]
 [tool.coverage.report]
 exclude_lines = [
     "if __name__ == .__main__.:",
-    "from .* import .*",
-    "import",
+    "^from .* import .*",
+    "^import .*",
     "pragma: no cover"
 ]
 fail_under = 100

--- a/src/aind_data_access_api/helpers/data_schema.py
+++ b/src/aind_data_access_api/helpers/data_schema.py
@@ -1,12 +1,14 @@
 """Module for convenience functions for the data access API."""
 
+import json
+
+from aind_data_schema.core.quality_control import QualityControl
+
 from aind_data_access_api.document_db import MetadataDbClient
 from aind_data_access_api.helpers.docdb import (
     get_field_by_id,
     get_id_from_name,
 )
-from aind_data_schema.core.quality_control import QualityControl
-import json
 
 
 def get_quality_control_by_id(

--- a/src/aind_data_access_api/helpers/data_schema.py
+++ b/src/aind_data_access_api/helpers/data_schema.py
@@ -56,8 +56,6 @@ def get_quality_control_by_name(
         return invalid QualityControl as dict if True, by default False
     """
     _id = get_id_from_name(client, name=name)
-    if not _id:
-        raise ValueError(f"No record found with name {name}")
 
     return get_quality_control_by_id(
         client, _id=_id, allow_invalid=allow_invalid

--- a/src/aind_data_access_api/helpers/docdb.py
+++ b/src/aind_data_access_api/helpers/docdb.py
@@ -1,8 +1,9 @@
 """Utilities that go through the MetadataDBClient """
 
-from typing import Optional
-from aind_data_access_api.document_db import MetadataDbClient
 import logging
+from typing import Optional
+
+from aind_data_access_api.document_db import MetadataDbClient
 
 
 def get_record_by_id(

--- a/src/aind_data_access_api/helpers/docdb.py
+++ b/src/aind_data_access_api/helpers/docdb.py
@@ -83,9 +83,11 @@ def get_field_by_id(
 def get_id_from_name(
     client: MetadataDbClient,
     name: str,
-) -> Optional[str]:
+) -> str:
     """
-    Get the _id of a record in DocDb from its name field.
+    Get the _id of a record in DocDb from its name field. If multiple share
+    the same name, only the first record is returned. If no record is found,
+    an exception is raised.
 
     Parameters
     ----------
@@ -94,21 +96,43 @@ def get_id_from_name(
 
     Returns
     -------
-    Optional[str]
-        None if record does not exist. Otherwise, it will return the _id of
-        the record.
+    str
+        The _id of the record with the given name.
     """
     records = client.retrieve_docdb_records(
-        filter_query={"name": name}, projection={"_id": 1}, limit=0
+        filter_query={"name": name}, projection={"_id": 1}
     )
-
     if len(records) > 1:
         logging.warning(
-            "Multiple records share the name {name}, ",
+            f"Multiple records share the name {name}, "
             "only the first record will be returned.",
         )
+    elif len(records) == 0:
+        raise ValueError(f"No record found with name {name}")
+    return records[0]["_id"]
 
-    if len(records) > 0:
-        return records[0]["_id"]
-    else:
-        return None
+
+def get_name_from_id(
+    client: MetadataDbClient,
+    _id: str,
+) -> str:
+    """
+    Get the name of a record in DocDb from its _id field. If no record is
+    found, an exception is raised.
+
+    Parameters
+    ----------
+    client : MetadataDbClient
+    _id : str
+
+    Returns
+    -------
+    str
+        The name of the record with the given _id.
+    """
+    records = client.retrieve_docdb_records(
+        filter_query={"_id": _id}, projection={"name": 1}, limit=1
+    )
+    if len(records) == 0:
+        raise ValueError(f"No record found with _id {_id}")
+    return records[0]["name"]

--- a/tests/test_helpers_data_schema.py
+++ b/tests/test_helpers_data_schema.py
@@ -1,21 +1,23 @@
-"""Test util.data_schema module."""
+"""Test helpers.data_schema module."""
 
-from pathlib import Path
-import unittest
 import json
+import os
+import unittest
+from pathlib import Path
 from unittest.mock import MagicMock
+
+from aind_data_schema.core.quality_control import QualityControl
+
 from aind_data_access_api.helpers.data_schema import (
     get_quality_control_by_id,
     get_quality_control_by_name,
 )
-from aind_data_schema.core.quality_control import QualityControl
-import os
 
 TEST_DIR = Path(os.path.dirname(os.path.realpath(__file__)))
 TEST_HELPERS_DIR = TEST_DIR / "resources" / "helpers"
 
 
-class TestUtilDataSchema(unittest.TestCase):
+class TestHelpersDataSchema(unittest.TestCase):
     """Test methods in data schema."""
 
     @classmethod
@@ -66,7 +68,6 @@ class TestUtilDataSchema(unittest.TestCase):
 
     def test_get_qc_no_record(self):
         """Test that a value error is raised when no record exists."""
-        # Get json dict from test file
         client = MagicMock()
         client.retrieve_docdb_records.return_value = []
 
@@ -107,7 +108,6 @@ class TestUtilDataSchema(unittest.TestCase):
 
     def test_get_qc_no_name(self):
         """Test that a value error is raised when no record exists."""
-        # Get json dict from test file
         client = MagicMock()
         client.retrieve_docdb_records.return_value = []
 

--- a/tests/test_helpers_docdb.py
+++ b/tests/test_helpers_docdb.py
@@ -1,4 +1,4 @@
-"""Tests methods in util.docdb module"""
+"""Tests methods in helpers.docdb module"""
 
 import unittest
 from unittest.mock import MagicMock, patch
@@ -12,8 +12,8 @@ from aind_data_access_api.helpers.docdb import (
 )
 
 
-class TestUtilDocDB(unittest.TestCase):
-    """Class to test methods in util.docdb module."""
+class TestHelpersDocDB(unittest.TestCase):
+    """Class to test methods in helpers.docdb module."""
 
     def test_get_id_from_name(self):
         """Tests get_id_from_name"""

--- a/tests/test_helpers_docdb.py
+++ b/tests/test_helpers_docdb.py
@@ -1,13 +1,14 @@
 """Tests methods in util.docdb module"""
 
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from aind_data_access_api.helpers.docdb import (
     get_record_by_id,
     get_id_from_name,
     get_projection_by_id,
     get_field_by_id,
+    get_name_from_id,
 )
 
 
@@ -21,6 +22,46 @@ class TestUtilDocDB(unittest.TestCase):
             {"_id": "abcd", "name": "123"}
         ]
         self.assertEqual("abcd", get_id_from_name(client, name="123"))
+
+    @patch("logging.warning")
+    def test_get_id_from_name_multiple(self, mock_warning):
+        """Tests get_id_from_name with multiple records"""
+        client = MagicMock()
+        client.retrieve_docdb_records.return_value = [
+            {"_id": "abcd"},
+            {"_id": "efgh"},
+        ]
+        result = get_id_from_name(client, name="123")
+        self.assertEqual("abcd", result)
+        mock_warning.assert_called_once_with(
+            "Multiple records share the name 123, "
+            "only the first record will be returned."
+        )
+
+    def test_get_id_from_name_error(self):
+        """Tests get_id_from_name with no records"""
+        client = MagicMock()
+        client.retrieve_docdb_records.return_value = []
+        with self.assertRaises(ValueError) as e:
+            get_id_from_name(client, name="123")
+        self.assertEqual("No record found with name 123", str(e.exception))
+
+    def test_get_name_from_id(self):
+        """Tests get_name_from_id"""
+        client = MagicMock()
+        client.retrieve_docdb_records.return_value = [
+            {"_id": "abcd", "name": "123"}
+        ]
+        result = get_name_from_id(client, _id="abcd")
+        self.assertEqual("123", result)
+
+    def test_get_name_from_id_error(self):
+        """Tests get_name_from_id with no records"""
+        client = MagicMock()
+        client.retrieve_docdb_records.return_value = []
+        with self.assertRaises(ValueError) as e:
+            get_name_from_id(client, _id="abcd")
+        self.assertEqual("No record found with _id abcd", str(e.exception))
 
     def test_get_record_from_docdb(self):
         """Tests get_record_from_docdb"""
@@ -53,3 +94,7 @@ class TestUtilDocDB(unittest.TestCase):
         ]
         field = get_field_by_id(client, _id="abcd", field="quality_control")
         self.assertEqual({"quality_control": {"a": 1}}, field)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
closes #103

Updates/adds `get_id_from_name` and `get_name_from_id` helper methods that raise ValueError for failed record searches. Only `get_id_from_name` prints warnings for multiple records since ids are unique.