### PR TITLE
Feat: Update docs to include install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,30 @@ API to interact with a few AIND databases. We have two primary databases:
    unstructured json documents. The DocDB contains AIND metadata.
 2. A relational database to store structured tables.
 
+## Installation
+
+Basic installation:
+```bash
+pip install aind-data-access-api
+```
+
+The package includes optional features that require additional dependencies:
+
+### Document Database (DocDB)
+To use the `MetadataDbClient` and other DocDB features:
+```bash
+pip install "aind-data-access-api[docdb]"
+```
+Note: The quotes are required when using zsh or other shells that interpret square brackets.
+
+### Relational Database
+For RDS functionality:
+```bash
+pip install "aind-data-access-api[rds]"
+```
+
+### Other Install Options
+- AWS Secrets management: `pip install "aind-data-access-api[secrets]"`
+- All features: `pip install "aind-data-access-api[full]"`
+
 More information can be found at [readthedocs](https://aind-data-access-api.readthedocs.io).

--- a/docs/source/UserGuide.rst
+++ b/docs/source/UserGuide.rst
@@ -213,6 +213,48 @@ explicitly setting credentials, or downloading from AWS Secrets Manager.
    # It's also possible to save a pandas dataframe as a table. Please check internal documentation for more details.
    ds_client.overwrite_table_with_df(df, table_name)
 
+
+Installation
+------------
+
+Basic installation:
+
+.. code:: bash
+
+   pip install aind-data-access-api
+
+Optional Dependencies
+~~~~~~~~~~~~~~~~~~~
+
+Different features require different optional dependencies:
+
+- To use DocDB features (including ``MetadataDbClient``):
+
+.. code:: bash
+
+   pip install "aind-data-access-api[docdb]"
+
+- To use RDS features:
+
+.. code:: bash
+
+   pip install "aind-data-access-api[rds]"
+
+- To use AWS Secrets management:
+
+.. code:: bash
+
+   pip install "aind-data-access-api[secrets]"
+
+- To install all optional dependencies:
+
+.. code:: bash
+
+   pip install "aind-data-access-api[full]"
+
+Note: When using zsh or other shells that interpret square brackets, the quotes around the install argument are required.
+
+
 Reporting bugs or making feature requests
 -----------------------------------------
 


### PR DESCRIPTION
Adds instructions to the `README.md` and to `docs.UserGuide.rst` to explain how to install the package with/without optional dependencies.

Solves issue #120 