### PR TITLE
BREAKING CHANGE: uses raise_for_status for requests

### DIFF
--- a/docs/source/ExamplesDocDBRestApi.rst
+++ b/docs/source/ExamplesDocDBRestApi.rst
@@ -153,6 +153,6 @@ It's possible to attach a custom Session to retry certain requests errors
         host=API_GATEWAY_HOST,
         database=DATABASE,
         collection=COLLECTION,
-        requests_session=session,
+        session=session,
     ) as docdb_api_client:
         records = docdb_api_client.retrieve_docdb_records(limit=10)

--- a/docs/source/ExamplesDocDBRestApi.rst
+++ b/docs/source/ExamplesDocDBRestApi.rst
@@ -121,3 +121,38 @@ Aggregation Example 1: Get all subjects per breeding group
 
 For more info about aggregations, please see MongoDB documentation:
 https://www.mongodb.com/docs/manual/aggregation/
+
+Advanced Example: Custom Session Object
+-------------------------------------------
+
+It's possible to attach a custom Session to retry certain requests errors
+
+.. code:: python
+
+    import requests
+    from requests.adapters import HTTPAdapter
+    from urllib3.util import Retry
+
+    from aind_data_access_api.document_db import MetadataDbClient
+
+    API_GATEWAY_HOST = "api.allenneuraldynamics.org"
+    DATABASE = "metadata_index"
+    COLLECTION = "data_assets"
+
+    retry = Retry(
+        total=5,
+        backoff_factor=1,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=["GET", "POST", "DELETE"],
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session = requests.Session()
+    session.mount("https://", adapter)
+
+    with MetadataDbClient(
+        host=API_GATEWAY_HOST,
+        database=DATABASE,
+        collection=COLLECTION,
+        requests_session=session,
+    ) as docdb_api_client:
+        records = docdb_api_client.retrieve_docdb_records(limit=10)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dynamic = ["version"]
 dependencies = [
     "requests",
     "aind-codeocean-api>=0.4.0",
+    "boto3",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",
     "aind-data-schema>=1.1.0",
@@ -36,7 +37,6 @@ dev = [
     "aind-data-access-api[full]",
 ]
 secrets = [
-    "boto3",
 ]
 docdb = [
     "pymongo==4.3.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "aind-codeocean-api>=0.4.0",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",
-    "aind-data-schema",
+    "aind-data-schema>=1.1.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_document_db.py
+++ b/tests/test_document_db.py
@@ -5,6 +5,7 @@ import unittest
 from datetime import datetime
 from unittest.mock import MagicMock, call, patch
 
+import requests.exceptions
 from requests import Response
 
 from aind_data_access_api.document_db import (
@@ -19,7 +20,7 @@ class TestClient(unittest.TestCase):
     """Test methods in Client class."""
 
     example_client_args = {
-        "host": "acmecorp.com/",
+        "host": "example.com/",
         "database": "db",
         "collection": "coll",
     }
@@ -28,20 +29,20 @@ class TestClient(unittest.TestCase):
         """Tests class constructor"""
         client = Client(**self.example_client_args)
 
-        self.assertEqual("acmecorp.com", client.host)
+        self.assertEqual("example.com", client.host)
         self.assertEqual("db", client.database)
         self.assertEqual("coll", client.collection)
-        self.assertEqual("https://acmecorp.com/v1/db/coll", client._base_url)
+        self.assertEqual("https://example.com/v1/db/coll", client._base_url)
         self.assertEqual(
-            "https://acmecorp.com/v1/db/coll/update_one",
+            "https://example.com/v1/db/coll/update_one",
             client._update_one_url,
         )
         self.assertEqual(
-            "https://acmecorp.com/v1/db/coll/bulk_write",
+            "https://example.com/v1/db/coll/bulk_write",
             client._bulk_write_url,
         )
 
-    @patch("requests.get")
+    @patch("requests.Session.get")
     def test_count_records(self, mock_get: MagicMock):
         """Tests _count_records method"""
 
@@ -62,23 +63,18 @@ class TestClient(unittest.TestCase):
             record_count,
         )
 
-    @patch("requests.get")
+    @patch("requests.Session.get")
     def test_count_records_error(self, mock_get: MagicMock):
         """Tests _count_records when there is a HTTP error"""
         client = Client(**self.example_client_args)
         mock_response = Response()
         mock_response.status_code = 400
-        mock_error = {"error": {"name": "Error", "message": "Incorrect Path"}}
-        mock_response._content = json.dumps(mock_error).encode("utf-8")
         mock_get.return_value = mock_response
-        with self.assertRaises(ValueError) as e:
+        with self.assertRaises(requests.exceptions.HTTPError) as e:
             client._count_records(filter_query={"_id": "abc"})
-        self.assertEqual(
-            f"ValueError('400 Error: {json.dumps(mock_error)}')",
-            repr(e.exception),
-        )
+        self.assertIn("400 Client Error", str(e.exception))
 
-    @patch("requests.get")
+    @patch("requests.Session.get")
     def test_get_records(self, mock_get: MagicMock):
         """Tests _get_records method"""
 
@@ -105,7 +101,7 @@ class TestClient(unittest.TestCase):
         records2 = client._get_records(
             filter_query={"_id": "abc123"},
             projection={"_id": 1, "message": 1},
-            sort=[("message", 1)],
+            sort={"message": 1},
         )
         self.assertEqual(
             [
@@ -116,37 +112,27 @@ class TestClient(unittest.TestCase):
         )
         self.assertEqual([{"_id": "abc123", "message": "hi"}], records2)
 
-    @patch("requests.get")
+    @patch("requests.Session.get")
     def test_get_records_error(self, mock_get: MagicMock):
         """Tests _get_records method when there is an HTTP error or
         no payload in response"""
         client = Client(**self.example_client_args)
         mock_response1 = Response()
         mock_response1.status_code = 404
-        mock_error = {
-            "error": {
-                "name": "Error",
-                "message": "Database or collection not found.",
-            }
-        }
-        mock_response1._content = json.dumps(mock_error).encode("utf-8")
         mock_response2 = Response()
         mock_response2.status_code = 200
         mock_response2._content = None
         mock_get.side_effect = [mock_response1, mock_response2]
-        with self.assertRaises(ValueError) as e:
+        with self.assertRaises(requests.exceptions.HTTPError) as e:
             client._get_records(filter_query={"_id": "abc"})
-        self.assertEqual(
-            f"ValueError('404 Error: {json.dumps(mock_error)}')",
-            repr(e.exception),
-        )
-        with self.assertRaises(ValueError) as e:
+        self.assertIn("404 Client Error", str(e.exception))
+        with self.assertRaises(requests.exceptions.JSONDecodeError) as e:
             client._get_records(filter_query={"_id": "4532654"})
-        self.assertEqual(
-            "ValueError('No payload in response')", repr(e.exception)
+        self.assertIn(
+            "Expecting value: line 1 column 1 (char 0)", str(e.exception)
         )
 
-    @patch("requests.post")
+    @patch("requests.Session.post")
     def test_aggregate_records(self, mock_post: MagicMock):
         """Tests _aggregate_records method"""
         pipeline = [{"$match": {"_id": "abc123"}}]
@@ -164,7 +150,7 @@ class TestClient(unittest.TestCase):
             result,
         )
 
-    @patch("requests.post")
+    @patch("requests.Session.post")
     def test_aggregate_records_error(self, mock_post: MagicMock):
         """Tests _aggregate_records method when there is an HTTP error or
         no payload in response"""
@@ -172,34 +158,22 @@ class TestClient(unittest.TestCase):
         client = Client(**self.example_client_args)
         mock_response1 = Response()
         mock_response1.status_code = 400
-        mock_error = {
-            "error": {
-                "name": "MongoServerError",
-                "message": (
-                    "Unrecognized pipeline stage name: '$match_invalid'"
-                ),
-            }
-        }
-        mock_response1._content = json.dumps(mock_error).encode("utf-8")
         mock_response2 = Response()
         mock_response2.status_code = 200
         mock_response2._content = None
         mock_post.side_effect = [mock_response1, mock_response2]
-        with self.assertRaises(ValueError) as e:
+        with self.assertRaises(requests.exceptions.HTTPError) as e:
             client._aggregate_records(pipeline=invalid_pipeline)
-        self.assertEqual(
-            f"400 Error: {json.dumps(mock_error)}",
-            str(e.exception),
-        )
-        with self.assertRaises(ValueError) as e:
+        self.assertIn("400 Client Error", str(e.exception))
+        with self.assertRaises(requests.exceptions.JSONDecodeError) as e:
             client._aggregate_records(pipeline=invalid_pipeline)
-        self.assertEqual(
-            "ValueError('No payload in response')", repr(e.exception)
+        self.assertIn(
+            "Expecting value: line 1 column 1 (char 0)", str(e.exception)
         )
 
     @patch("boto3.session.Session")
     @patch("botocore.auth.SigV4Auth.add_auth")
-    @patch("requests.post")
+    @patch("requests.Session.post")
     def test_upsert_one_record(
         self,
         mock_post: MagicMock,
@@ -220,7 +194,7 @@ class TestClient(unittest.TestCase):
         )
         mock_auth.assert_called_once()
         mock_post.assert_called_once_with(
-            url="https://acmecorp.com/v1/db/coll/update_one",
+            url="https://example.com/v1/db/coll/update_one",
             headers={"Content-Type": "application/json"},
             data=(
                 '{"filter": {"_id": "123"},'
@@ -231,7 +205,7 @@ class TestClient(unittest.TestCase):
 
     @patch("boto3.session.Session")
     @patch("botocore.auth.SigV4Auth.add_auth")
-    @patch("requests.post")
+    @patch("requests.Session.post")
     def test_bulk_write(
         self,
         mock_post: MagicMock,
@@ -265,7 +239,7 @@ class TestClient(unittest.TestCase):
         client._bulk_write(operations=operations)
         mock_auth.assert_called_once()
         mock_post.assert_called_once_with(
-            url="https://acmecorp.com/v1/db/coll/bulk_write",
+            url="https://example.com/v1/db/coll/bulk_write",
             headers={"Content-Type": "application/json"},
             data=(
                 '[{"UpdateOne":'
@@ -281,7 +255,7 @@ class TestClient(unittest.TestCase):
 
     @patch("boto3.session.Session")
     @patch("botocore.auth.SigV4Auth.add_auth")
-    @patch("requests.delete")
+    @patch("requests.Session.delete")
     def test_delete_one_record(
         self,
         mock_delete: MagicMock,
@@ -299,14 +273,14 @@ class TestClient(unittest.TestCase):
         client._delete_one_record(record_filter={"_id": "123"})
         mock_auth.assert_called_once()
         mock_delete.assert_called_once_with(
-            url="https://acmecorp.com/v1/db/coll/delete_one",
+            url="https://example.com/v1/db/coll/delete_one",
             headers={"Content-Type": "application/json"},
             data=('{"filter": {"_id": "123"}}'),
         )
 
     @patch("boto3.session.Session")
     @patch("botocore.auth.SigV4Auth.add_auth")
-    @patch("requests.delete")
+    @patch("requests.Session.delete")
     def test_delete_many_records(
         self,
         mock_delete: MagicMock,
@@ -326,9 +300,45 @@ class TestClient(unittest.TestCase):
         )
         mock_auth.assert_called_once()
         mock_delete.assert_called_once_with(
-            url="https://acmecorp.com/v1/db/coll/delete_many",
+            url="https://example.com/v1/db/coll/delete_many",
             headers={"Content-Type": "application/json"},
             data=('{"filter": {"_id": {"$in": ["123", "456"]}}}'),
+        )
+
+    @patch("aind_data_access_api.document_db.Session")
+    def test_content_manager(
+        self,
+        mock_session: MagicMock,
+    ):
+        """Tests request session closes when client is in context manager."""
+        mock_response = Response()
+        mock_response.status_code = 200
+        mock_records_counts = {
+            "total_record_count": 1234,
+            "filtered_record_count": 47,
+        }
+        mock_response._content = json.dumps(mock_records_counts).encode(
+            "utf-8"
+        )
+        mock_session.return_value.get.return_value = mock_response
+        with Client(**self.example_client_args) as client:
+            record_count = client._count_records(filter_query={"_id": "abc"})
+        self.assertEqual(
+            mock_records_counts,
+            record_count,
+        )
+        mock_session.assert_has_calls(
+            [
+                call(),
+                call().get(
+                    "https://example.com/v1/db/coll",
+                    params={
+                        "count_records": "True",
+                        "filter": '{"_id": "abc"}',
+                    },
+                ),
+                call().close(),
+            ]
         )
 
 
@@ -336,7 +346,7 @@ class TestMetadataDbClient(unittest.TestCase):
     """Test methods in MetadataDbClient class."""
 
     example_client_args = {
-        "host": "acmecorp.com/",
+        "host": "example.com/",
         "database": "metadata_db",
         "collection": "data_assets",
     }
@@ -999,7 +1009,7 @@ class TestSchemaDbClient(unittest.TestCase):
 
         schema_type = "procedures"
         schema_version = "abc-123"
-        client = SchemaDbClient(host="acmecorp.com/", collection=schema_type)
+        client = SchemaDbClient(host="example.com/", collection=schema_type)
         expected_response = [
             {
                 "_id": "abc-123",

--- a/tests/test_helpers_docdb.py
+++ b/tests/test_helpers_docdb.py
@@ -4,11 +4,11 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from aind_data_access_api.helpers.docdb import (
-    get_record_by_id,
-    get_id_from_name,
-    get_projection_by_id,
     get_field_by_id,
+    get_id_from_name,
     get_name_from_id,
+    get_projection_by_id,
+    get_record_by_id,
 )
 
 


### PR DESCRIPTION
Closes #6
Closes #108 

- Allows user to pass in requests.Session object
- Uses raise_for_status for requests exceptions (This will introduce a breaking change if users added error handlers in their code)
- Updates some urls in tests to be example.com
- Adds lower bound to aind-data-schema
- Changes cached_property to property
- Updates internal property names
- Moves boto3 to core requirement since it's required to use the docdb write methods