### PR TITLE
feat: support insert_one and updates to nested fields

### DIFF
--- a/docs/source/ExamplesDocDBDirectConnection.rst
+++ b/docs/source/ExamplesDocDBDirectConnection.rst
@@ -140,8 +140,7 @@ functions to update records in DocDB.
       DocumentDbSSHCredentials,
   )
   from aind_data_schema.core.metadata import Metadata
-
-  from aind_data_access_api.utils import paginate_docdb, is_dict_corrupt
+  from aind_data_access_api.utils import paginate_docdb
 
   logging.basicConfig(level="INFO")
 
@@ -216,9 +215,6 @@ functions to update records in DocDB.
                   **new_record
               ).model_dump_json(warnings=False, by_alias=True)
               new_record = json.loads(new_record_str)
-              if is_dict_corrupt(new_record):
-                  logging.warning(f"New record for {location} is corrupt! Skipping.")
-                  new_record = None
           except Exception:
               new_record = None
       return new_record
@@ -257,9 +253,6 @@ functions to update records in DocDB.
           The new record to replace the existing record with.
 
       """
-      if is_dict_corrupt(new_record) or record_id != new_record.get("_id"):
-          logging.warning(f"Attempting to update corrupt record {record_id}! Skipping.")
-          return
       if dryrun:
           logging.info(f"(dryrun) doc_db_client.collection.update_one: {record_id}")
       else:

--- a/docs/source/ExamplesDocDBRestApi.rst
+++ b/docs/source/ExamplesDocDBRestApi.rst
@@ -188,7 +188,6 @@ For example, to update the "rig" and "session" metadata of a record in DocDB:
       response = docdb_api_client.upsert_one_docdb_record(
           record=record_update
       )
-      response.raise_for_status()
       print(response.json())
 
 You can also make updates to individual nested fields:
@@ -203,7 +202,6 @@ You can also make updates to individual nested fields:
   response = docdb_api_client.upsert_one_docdb_record(
       record=record_update
   )
-  response.raise_for_status()
   print(response.json())
 
 Please note that while DocumentDB supports fieldnames with special characters ("$" and "."), they are not recommended.

--- a/docs/source/ExamplesDocDBRestApi.rst
+++ b/docs/source/ExamplesDocDBRestApi.rst
@@ -166,7 +166,8 @@ Updating Metadata
 2. **Query DocDB**: Filter for the records you want to update.
 3. **Update DocDB**: Use ``upsert_one_docdb_record`` or ``upsert_list_of_docdb_records`` to update the records.
 
-For example, to update the "rig" and "session" metadata of a record in DocDB:
+Please note that records are read and written as dictionaries from DocDB (not Pydantic models).
+For example, to update the "instrument" and "session" metadata of a record in DocDB:
 
 .. code:: python
 
@@ -177,14 +178,23 @@ For example, to update the "rig" and "session" metadata of a record in DocDB:
   )
   print(f"Found {len(records)} records in DocDB matching filter.")
 
-  # update rig and session metadata for each record
   for record in records:
+      # NOTE: provide core metadata as dictionaries
+      # e.g. update some field from the queried result
+      instrument = record["instrument"] # dictionary
+      instrument["instrument_type"] = "New Instrument Type"  
+      # e.g. replace entirely from file
+      with open(INSTRUMENT_FILE_PATH, "r") as f:
+          instrument = json.load(f)
+      # e.g. convert Pydantic model to dictionary
+      session = session_model.model_dump()
+
+      # update record in docdb
       record_update = {
           "_id": record["_id"],
-          "rig": rig,
+          "instrument": instrument,
           "session": session
       }
-
       response = docdb_api_client.upsert_one_docdb_record(
           record=record_update
       )

--- a/docs/source/ExamplesDocDBRestApi.rst
+++ b/docs/source/ExamplesDocDBRestApi.rst
@@ -121,3 +121,56 @@ Aggregation Example 1: Get all subjects per breeding group
 
 For more info about aggregations, please see MongoDB documentation:
 https://www.mongodb.com/docs/manual/aggregation/
+
+
+Updating Metadata
+~~~~~~~~~~~~~~~~~~~~~~
+
+1. **Permissions**: Request permissions for AWS Credentials to write to DocDB through the API Gateway.
+2. **Query DocDB**: Filter for the records you want to update.
+3. **Update DocDB**: Use ``upsert_one_docdb_record`` or ``upsert_list_of_docdb_records`` to update the records.
+
+For example, to update the "rig" and "session" metadata of a record in DocDB:
+
+.. code:: python
+
+  # filter for records you want to update
+  records = docdb_api_client.retrieve_docdb_records(
+      filter_query=filter,
+      projection=projection, # recommended
+  )
+  print(f"Found {len(records)} records in DocDB matching filter.")
+
+  # update rig and session metadata for each record
+  for record in records:
+      record_update = {
+          "_id": record["_id"],
+          "rig": rig,
+          "session": session
+      }
+
+      response = docdb_api_client.upsert_one_docdb_record(
+          record=record_update
+      )
+      response.raise_for_status()
+      print(response.json())
+
+You can also make updates to individual nested fields:
+
+.. code:: python
+
+  record_update = {
+      "_id": record["_id"],
+      "data_description.project_name": project_name, # nested field
+  }
+
+  response = docdb_api_client.upsert_one_docdb_record(
+      record=record_update
+  )
+  response.raise_for_status()
+  print(response.json())
+
+Please note that while DocumentDB supports fieldnames with special characters ("$" and "."), they are not recommended.
+There may be issues querying or updating these fields.
+
+It is recommended to avoid these special chars in dictionary keys, e.g. ``{"abc.py": "data"}`` can be written as ``{"filename": "abc.py", "some_file_property": "data"}`` instead.

--- a/src/aind_data_access_api/document_db.py
+++ b/src/aind_data_access_api/document_db.py
@@ -62,7 +62,7 @@ class Client:
         )
 
     @property
-    def _insert_one_url(self):
+    def _insert_one_url(self) -> str:
         """Url to insert one record"""
         return (
             f"https://{self.host}/{self.version}/{self.database}/"
@@ -219,11 +219,13 @@ class Client:
         signed_header = self._signed_request(
             method="POST", url=self._insert_one_url, data=data
         )
-        return requests.post(
+        response = self.session.post(
             url=self._insert_one_url,
             headers=dict(signed_header.headers),
             data=data,
         )
+        response.raise_for_status()
+        return response
 
     def _upsert_one_record(
         self, record_filter: dict, update: dict

--- a/src/aind_data_access_api/document_db.py
+++ b/src/aind_data_access_api/document_db.py
@@ -14,7 +14,6 @@ from botocore.awsrequest import AWSRequest
 from requests import Response
 
 from aind_data_access_api.models import DataAssetRecord
-from aind_data_access_api.utils import is_dict_corrupt
 
 
 class Client:
@@ -484,8 +483,6 @@ class MetadataDbClient(Client):
         """Upsert one record if the record is not corrupt"""
         if record.get("_id") is None:
             raise ValueError("Record does not have an _id field.")
-        if is_dict_corrupt(record):
-            raise ValueError("Record is corrupt and cannot be upserted.")
         response = self._upsert_one_record(
             record_filter={"_id": record["_id"]},
             update={"$set": json.loads(json.dumps(record, default=str))},
@@ -582,10 +579,6 @@ class MetadataDbClient(Client):
             for record in records:
                 if record.get("_id") is None:
                     raise ValueError("A record does not have an _id field.")
-                if is_dict_corrupt(record):
-                    raise ValueError(
-                        "A record is corrupt and cannot be upserted."
-                    )
             # chunk records
             first_index = 0
             end_index = len(records)

--- a/src/aind_data_access_api/utils.py
+++ b/src/aind_data_access_api/utils.py
@@ -1,5 +1,6 @@
 """Package for common methods used for interfacing with DocDB."""
 
+import warnings
 from typing import Dict, Iterator, List, Optional
 from urllib.parse import urlparse
 
@@ -46,8 +47,12 @@ def get_s3_location(bucket: str, prefix: str) -> str:
     return f"s3://{bucket}/{stripped_prefix}"
 
 
+# TODO: deprecate this method
 def is_dict_corrupt(input_dict: dict) -> bool:
     """
+    DEPRECATED: This method is deprecated. Special chars in fieldnames are
+    allowed but not recommended.
+
     Checks that all the keys, included nested keys, don't contain '$' or '.'
     Parameters
     ----------
@@ -60,6 +65,13 @@ def is_dict_corrupt(input_dict: dict) -> bool:
       forbidden characters. False otherwise.
 
     """
+    warnings.warn(
+        "is_dict_corrupt is deprecated. Special chars in fieldnames are "
+        "allowed but not recommended."
+        "",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     if not isinstance(input_dict, dict):
         return True
     for key, value in input_dict.items():

--- a/tests/test_document_db.py
+++ b/tests/test_document_db.py
@@ -611,10 +611,8 @@ class TestMetadataDbClient(unittest.TestCase):
         )
 
     @patch("aind_data_access_api.document_db.Client._upsert_one_record")
-    def test_upsert_one_docdb_record_invalid_corrupt(
-        self, mock_upsert: MagicMock
-    ):
-        """Tests upserting one docdb record if record is invalid or corrupt"""
+    def test_upsert_one_docdb_record_invalid(self, mock_upsert: MagicMock):
+        """Tests upserting one docdb record if record is invalid"""
         client = MetadataDbClient(**self.example_client_args)
         record_no__id = {
             "id": "abc-123",
@@ -623,19 +621,10 @@ class TestMetadataDbClient(unittest.TestCase):
             "location": "some_url",
             "subject": {"subject_id": "00000", "sex": "Female"},
         }
-        record_corrupt = {
-            "_id": "abc-123",
-            "name.corrupt": "modal_00000_2000-10-10_10-10-10",
-        }
         with self.assertRaises(ValueError) as e:
             client.upsert_one_docdb_record(record_no__id)
         self.assertEqual(
             "Record does not have an _id field.", str(e.exception)
-        )
-        with self.assertRaises(ValueError) as e:
-            client.upsert_one_docdb_record(record_corrupt)
-        self.assertEqual(
-            "Record is corrupt and cannot be upserted.", str(e.exception)
         )
         mock_upsert.assert_not_called()
 
@@ -794,11 +783,10 @@ class TestMetadataDbClient(unittest.TestCase):
         )
 
     @patch("aind_data_access_api.document_db.Client._bulk_write")
-    def test_upsert_list_of_docdb_records_invalid_corrupt(
+    def test_upsert_list_of_docdb_records_invalid(
         self, mock_bulk_write: MagicMock
     ):
-        """Tests upserting a list of docdb records if a record is invalid or
-        corrupt"""
+        """Tests upserting a list of docdb records if a record is invalid"""
 
         client = MetadataDbClient(**self.example_client_args)
         records_no__id = [
@@ -817,31 +805,10 @@ class TestMetadataDbClient(unittest.TestCase):
                 "subject": {"subject_id": "00000", "sex": "Male"},
             },
         ]
-        records_corrupt = [
-            {
-                "_id": "abc-123",
-                "name": "modal_00000_2000-10-10_10-10-10",
-                "created": datetime(2000, 10, 10, 10, 10, 10),
-                "location": "some_url",
-                "subject": {"subject_id": "00000", "sex": "Female"},
-            },
-            {
-                "_id": "abc-125",
-                "name.corrupt": "modal_00001_2000-10-10_10-10-10",
-                "created": datetime(2000, 10, 10, 10, 10, 10),
-                "location": "some_url",
-                "subject": {"subject_id": "00000", "sex": "Male"},
-            },
-        ]
         with self.assertRaises(ValueError) as e:
             client.upsert_list_of_docdb_records(records_no__id)
         self.assertEqual(
             "A record does not have an _id field.", str(e.exception)
-        )
-        with self.assertRaises(ValueError) as e:
-            client.upsert_list_of_docdb_records(records_corrupt)
-        self.assertEqual(
-            "A record is corrupt and cannot be upserted.", str(e.exception)
         )
         mock_bulk_write.assert_not_called()
 

--- a/tests/test_document_db.py
+++ b/tests/test_document_db.py
@@ -173,7 +173,7 @@ class TestClient(unittest.TestCase):
 
     @patch("boto3.session.Session")
     @patch("botocore.auth.SigV4Auth.add_auth")
-    @patch("requests.post")
+    @patch("requests.Session.post")
     def test_insert_one_record(
         self,
         mock_post: MagicMock,
@@ -193,7 +193,7 @@ class TestClient(unittest.TestCase):
         )
         mock_auth.assert_called_once()
         mock_post.assert_called_once_with(
-            url="https://acmecorp.com/v1/db/coll/insert_one",
+            url="https://example.com/v1/db/coll/insert_one",
             headers={"Content-Type": "application/json"},
             data=('{"_id": "123", "message": "hi"}'),
         )


### PR DESCRIPTION
closes #125 
closes #104 

A new insert endpoint is being added to the DocDB REST API at `/v1/{database}/{collection}/insert_one`.

This PR adds support for writing fieldnames with special chars:
- adds `insert_one_docdb_record` in `MetadataDbClient`
- remove `is_dict_corrupt` checks. This also enables updates to nested fields as requested by #104
- update docs