### PR TITLE
fix: do not drop large record batches

### DIFF
--- a/src/aind_data_access_api/document_db.py
+++ b/src/aind_data_access_api/document_db.py
@@ -368,9 +368,9 @@ class MetadataDbClient(Client):
         projection: Optional[dict] = None,
         sort: Optional[dict] = None,
         limit: int = 0,
-        paginate: bool = True,
-        paginate_batch_size: int = 500,
-        paginate_max_iterations: int = 20000,
+        paginate: Optional[bool] = None,
+        paginate_batch_size: Optional[int] = None,
+        paginate_max_iterations: Optional[int] = None,
     ) -> List[dict]:
         """
         Retrieve raw json records from DocDB API Gateway as a list of dicts.

--- a/src/aind_data_access_api/document_db.py
+++ b/src/aind_data_access_api/document_db.py
@@ -51,6 +51,14 @@ class Client:
         )
 
     @property
+    def _count_url(self) -> str:
+        """Url to count records."""
+        return (
+            f"https://{self.host}/{self.version}/{self.database}/"
+            f"{self.collection}/count_documents"
+        )
+
+    @property
     def _aggregate_url(self) -> str:
         """Url to aggregate records."""
         return (
@@ -150,12 +158,12 @@ class Client:
           Has keys {"total_record_count": int, "filtered_record_count": int}
 
         """
-        params = {
-            "count_records": str(True),
-        }
-        if filter_query is not None:
-            params["filter"] = json.dumps(filter_query)
-        response = self.session.get(self._base_url, params=params)
+        params = (
+            {"filter": json.dumps(filter_query)}
+            if filter_query is not None
+            else None
+        )
+        response = self.session.get(self._count_url, params=params)
         response.raise_for_status()
         response_body = response.json()
         return response_body

--- a/src/aind_data_access_api/utils.py
+++ b/src/aind_data_access_api/utils.py
@@ -71,7 +71,6 @@ def does_metadata_record_exist_in_docdb(
     records = docdb_api_client.retrieve_docdb_records(
         filter_query={"location": location},
         projection={"_id": 1},
-        paginate=False,
         limit=1,
     )
     if len(records) == 0:
@@ -100,7 +99,7 @@ def get_record_from_docdb(
 
     """
     records = docdb_api_client.retrieve_docdb_records(
-        filter_query={"_id": record_id}, paginate=False, limit=1
+        filter_query={"_id": record_id}, limit=1
     )
     if len(records) > 0:
         return records[0]
@@ -136,7 +135,7 @@ def paginate_docdb(
         projection = {}
     skip = 0
     while True:
-        page = docdb_api_client._get_records(
+        page = docdb_api_client._find_records(
             filter_query=filter_query,
             projection=projection,
             limit=page_size,
@@ -145,7 +144,7 @@ def paginate_docdb(
         if not page:
             break
         yield page
-        skip += page_size
+        skip += len(page)
 
 
 def build_docdb_location_to_id_map(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -121,7 +121,7 @@ class TestUtils(unittest.TestCase):
     @patch("aind_data_access_api.document_db.MetadataDbClient")
     def test_paginate_docdb(self, mock_docdb_api_client: MagicMock):
         """Tests paginate_docdb"""
-        mock_docdb_api_client._get_records.side_effect = [
+        mock_docdb_api_client._find_records.side_effect = [
             [self.example_metadata_nd, self.example_metadata_nd1],
             [self.example_metadata_nd2],
             [],


### PR DESCRIPTION
fixes https://github.com/AllenNeuralDynamics/aind-lambda-functions/issues/146

This PR updates `MetadataDbClient` so that we do not drop large batches:
- `_find_records`: sends requests to new /find endpoint which fetches "dynamic" batches of records
- `retrieve_docdb_records`: paginates docdb using new /find endpoint until there are no more records or the limit is reached

Please note that "paginate" parameters were marked as deprecated. Users can still provide them, but they are not used.