### PR TITLE
feat: add get_quality_control_df to easily return evaluations/metrics in dataframe format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ rds = [
     "SQLAlchemy==1.4.49"
 ]
 helpers = [
-    "aind-data-schema<2.0.0>",
+    "aind-data-schema<2.0.0",
     "pandas",
 ]
 full = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,8 @@ rds = [
     "SQLAlchemy==1.4.49"
 ]
 helpers = [
-    "aind-data-schema>=1.1.0",
+    "aind-data-schema<2.0.0>",
+    "pandas",
 ]
 full = [
     "aind-data-access-api[secrets]",

--- a/src/aind_data_access_api/helpers/data_schema.py
+++ b/src/aind_data_access_api/helpers/data_schema.py
@@ -1,6 +1,8 @@
 """Module for convenience functions for the data access API."""
 
 import json
+import pandas as pd
+from typing import List
 
 from aind_data_schema.core.quality_control import QualityControl
 
@@ -74,3 +76,35 @@ def validate_qc(qc_data: dict, allow_invalid: bool = False):
             return qc_data
         else:
             raise e
+
+
+def get_quality_control_df(
+    client: MetadataDbClient,
+    ids: List[str],
+):
+    """Using a connected DocumentDB client, retrieve a valid QC object as a dataframe
+
+    Parameters
+    ----------
+    client : MetadataDbClient
+        A connected DocumentDB client.
+    _id : str, optional
+        _id field in DocDB, by default empty
+    allow_invalid : bool, optional
+        return invalid QualityControl as dict if True, by default False
+    """
+    qcs = [get_quality_control_by_id(client, _id=_id, allow_invalid=False) for _id in ids]
+
+    data = []
+
+    for _id, qc in zip(ids, qcs):
+        qc_metrics_flat = {}
+        qc_metrics_flat["_id"] = _id
+        for eval in qc.evaluations:
+            for metric in eval.metrics:
+                qc_metrics_flat[f"{eval.name}_{metric.name}.value"] = metric.value
+                qc_metrics_flat[f"{eval.name}_{metric.name}.status"] = metric.status.status
+
+        data.append(qc_metrics_flat)
+
+    return pd.DataFrame(data)


### PR DESCRIPTION
This is a draft PR to test the idea of returning the QC values/statuses of objects in an easy-to-use dataframe. Returns a dataframe formatted like this:

```
       _id  Evaluation0_Metric0.value Evaluation0_Metric0.status
0  fake_id                          0                Status.PASS
```