### PR TITLE
docs: add link back to github

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,7 +7,7 @@
 Welcome to this repository's documentation!
 ===========================================
 
-`aind-data-access-api <https://github.com/AllenNeuralDynamics/aind-data-access-api>`_
+`aind-data-access-api code <https://github.com/AllenNeuralDynamics/aind-data-access-api>`_
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,6 +7,8 @@
 Welcome to this repository's documentation!
 ===========================================
 
+`aind-data-access-api <https://github.com/AllenNeuralDynamics/aind-data-access-api>`_
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,7 +7,7 @@
 Welcome to this repository's documentation!
 ===========================================
 
-`aind-data-access-api code <https://github.com/AllenNeuralDynamics/aind-data-access-api>`_
+`aind-data-access-api GitHub repository <https://github.com/AllenNeuralDynamics/aind-data-access-api>`_
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
PR adds a link back from the documentation to the github code on the frontpage. (Requested by Tom for all sci comp RTD repos)