### PR TITLE
feat: MetadataDbClient.register_asset method to POST /v1/assets/register

### DIFF
--- a/src/aind_data_access_api/document_db.py
+++ b/src/aind_data_access_api/document_db.py
@@ -615,12 +615,32 @@ class MetadataDbClient(Client):
         """Url to get LLM-generated summaries"""
         return f"https://{self.host}/{self.version}/data_summary"
 
+    @property
+    def _register_asset_url(self) -> str:
+        """Url to register an asset to DocDB and Code Ocean"""
+        return f"https://{self.host}/{self.version}/assets/register"
+
     def generate_data_summary(self, record_id: str) -> Dict[str, Any]:
         """Get an LLM-generated summary for a data asset."""
         url = f"{self._data_summary_url}/{record_id}"
         signed_header = self._signed_request(method="GET", url=url)
         response = self.session.get(
             url=url, headers=dict(signed_header.headers)
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def register_asset(self, s3_location: str) -> Dict[str, Any]:
+        """Register a data asset to Code Ocean and the DocDB metadata index."""
+
+        data = json.dumps({"s3_location": s3_location})
+        signed_header = self._signed_request(
+            method="POST", url=self._register_asset_url, data=data
+        )
+        response = self.session.post(
+            url=self._register_asset_url,
+            headers=dict(signed_header.headers),
+            data=data,
         )
         response.raise_for_status()
         return response.json()

--- a/tests/test_document_db.py
+++ b/tests/test_document_db.py
@@ -885,6 +885,10 @@ class TestMetadataDbClient(unittest.TestCase):
         self.assertEqual(
             "https://example.com/v1/data_summary", client._data_summary_url
         )
+        self.assertEqual(
+            "https://example.com/v1/assets/register",
+            client._register_asset_url,
+        )
 
         client = MetadataDbClient(**self.example_client_args, version="v2")
         self.assertEqual("v2", client.version)
@@ -931,6 +935,43 @@ class TestMetadataDbClient(unittest.TestCase):
         mock_get.assert_called_once_with(
             url="https://example.com/v1/data_summary/abc-123",
             headers={"Content-Type": "application/json"},
+        )
+        self.assertEqual(response_message, response)
+
+    @patch("boto3.session.Session")
+    @patch("botocore.auth.SigV4Auth.add_auth")
+    @patch("requests.Session.post")
+    def test_register_asset(
+        self,
+        mock_post: MagicMock,
+        mock_auth: MagicMock,
+        mock_session: MagicMock,
+    ):
+        """Tests register_asset method"""
+        mock_creds = MagicMock()
+        mock_creds.access_key = "abc"
+        mock_creds.secret_key = "efg"
+        mock_session.return_value.region_name = "us-west-2"
+        mock_session.get_credentials.return_value = mock_creds
+        mock_response = Response()
+        mock_response.status_code = 201
+        response_message = {
+            "message": (
+                "Processed s3://bucket/prefix for CO and DocDB registration."
+            ),
+            "registered_co": True,
+            "registered_docdb": True,
+        }
+        mock_response._content = json.dumps(response_message).encode("utf-8")
+        mock_post.return_value = mock_response
+
+        client = MetadataDbClient(**self.example_client_args)
+        response = client.register_asset("s3://bucket/prefix")
+        mock_auth.assert_called_once()
+        mock_post.assert_called_once_with(
+            url="https://example.com/v1/assets/register",
+            headers={"Content-Type": "application/json"},
+            data='{"s3_location": "s3://bucket/prefix"}',
         )
         self.assertEqual(response_message, response)
 


### PR DESCRIPTION
closes #165 

Adds method to sign and send POST request to new asset registration endpoint: `/v1/assets/register`

Usage:
```py
response = docdb_client.register_asset(s3_location=s3_location)
```

Example responses:
- Status 201: `{'message': 'Processed s3://aind-open-data-dev-u5u0i5/demo_000000_2025-08-14_00-00-00 for CO and DocDB registration.', 'registered_co': True, 'registered_docdb': True}`
- Status 200: `{'message': 'Asset s3://aind-open-data-dev-u5u0i5/demo_000000_2025-08-14_00-00-00 is already registered in DocDB and Code Ocean.', 'registered_co': True, 'registered_docdb': True}`
- Status 500: `{"message": "There was an error processing the request: ValueError('Invalid s3_location: s3://bucket.')."}`
