### PR TITLE
feat: MetadataDbClient.deregister_asset method

### DIFF
--- a/src/aind_data_access_api/document_db.py
+++ b/src/aind_data_access_api/document_db.py
@@ -620,6 +620,11 @@ class MetadataDbClient(Client):
         """Url to register an asset to DocDB and Code Ocean"""
         return f"https://{self.host}/{self.version}/assets/register"
 
+    @property
+    def _deregister_asset_url(self) -> str:
+        """Url to deregister (delete) an asset in DocDB and Code Ocean"""
+        return f"https://{self.host}/{self.version}/assets/deregister"
+
     def generate_data_summary(self, record_id: str) -> Dict[str, Any]:
         """Get an LLM-generated summary for a data asset."""
         url = f"{self._data_summary_url}/{record_id}"
@@ -639,6 +644,22 @@ class MetadataDbClient(Client):
         )
         response = self.session.post(
             url=self._register_asset_url,
+            headers=dict(signed_header.headers),
+            data=data,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def deregister_asset(self, s3_location: str) -> Dict[str, Any]:
+        """De-register (delete) a data asset in Code Ocean and the
+        DocDB metadata index."""
+
+        data = json.dumps({"s3_location": s3_location})
+        signed_header = self._signed_request(
+            method="DELETE", url=self._deregister_asset_url, data=data
+        )
+        response = self.session.delete(
+            url=self._deregister_asset_url,
             headers=dict(signed_header.headers),
             data=data,
         )

--- a/tests/test_document_db.py
+++ b/tests/test_document_db.py
@@ -889,6 +889,10 @@ class TestMetadataDbClient(unittest.TestCase):
             "https://example.com/v1/assets/register",
             client._register_asset_url,
         )
+        self.assertEqual(
+            "https://example.com/v1/assets/deregister",
+            client._deregister_asset_url,
+        )
 
         client = MetadataDbClient(**self.example_client_args, version="v2")
         self.assertEqual("v2", client.version)
@@ -970,6 +974,43 @@ class TestMetadataDbClient(unittest.TestCase):
         mock_auth.assert_called_once()
         mock_post.assert_called_once_with(
             url="https://example.com/v1/assets/register",
+            headers={"Content-Type": "application/json"},
+            data='{"s3_location": "s3://bucket/prefix"}',
+        )
+        self.assertEqual(response_message, response)
+
+    @patch("boto3.session.Session")
+    @patch("botocore.auth.SigV4Auth.add_auth")
+    @patch("requests.Session.delete")
+    def test_deregister_asset(
+        self,
+        mock_delete: MagicMock,
+        mock_auth: MagicMock,
+        mock_session: MagicMock,
+    ):
+        """Tests deregister_asset method"""
+        mock_creds = MagicMock()
+        mock_creds.access_key = "abc"
+        mock_creds.secret_key = "efg"
+        mock_session.return_value.region_name = "us-west-2"
+        mock_session.get_credentials.return_value = mock_creds
+        mock_response = Response()
+        mock_response.status_code = 200
+        response_message = {
+            "message": (
+                "Processed s3://bucket/prefix for CO and DocDB deregistration."
+            ),
+            "deregistered_co": True,
+            "deregistered_docdb": True,
+        }
+        mock_response._content = json.dumps(response_message).encode("utf-8")
+        mock_delete.return_value = mock_response
+
+        client = MetadataDbClient(**self.example_client_args)
+        response = client.deregister_asset("s3://bucket/prefix")
+        mock_auth.assert_called_once()
+        mock_delete.assert_called_once_with(
+            url="https://example.com/v1/assets/deregister",
             headers={"Content-Type": "application/json"},
             data='{"s3_location": "s3://bucket/prefix"}',
         )


### PR DESCRIPTION
closes #170

Adds method to sign and send DELETE request to new asset de-registration endpoint: `/v1/assets/deregister`

Usage:
```py
response = docdb_client.deregister_asset(s3_location=s3_location)
```